### PR TITLE
Fix ^= not being recognized in conditions 

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -1354,7 +1354,7 @@ class StatementListParser extends AbstractParser<IStatementListNode>
 	}
 
 	private static final Set<SyntaxKind> CONDITIONAL_OPERATOR_START = Set
-		.of(SyntaxKind.EQUALS_SIGN, SyntaxKind.EQ, SyntaxKind.EQUAL, SyntaxKind.LESSER_GREATER, SyntaxKind.NE, SyntaxKind.NOT, SyntaxKind.LESSER_SIGN, SyntaxKind.LT, SyntaxKind.LESS, SyntaxKind.LESSER_EQUALS_SIGN, SyntaxKind.LE, SyntaxKind.GREATER_SIGN, SyntaxKind.GT, SyntaxKind.GREATER, SyntaxKind.GREATER_EQUALS_SIGN, SyntaxKind.GE);
+		.of(SyntaxKind.EQUALS_SIGN, SyntaxKind.EQ, SyntaxKind.EQUAL, SyntaxKind.LESSER_GREATER, SyntaxKind.NE, SyntaxKind.NOT, SyntaxKind.CIRCUMFLEX_EQUAL, SyntaxKind.LESSER_SIGN, SyntaxKind.LT, SyntaxKind.LESS, SyntaxKind.LESSER_EQUALS_SIGN, SyntaxKind.LE, SyntaxKind.GREATER_SIGN, SyntaxKind.GT, SyntaxKind.GREATER, SyntaxKind.GREATER_EQUALS_SIGN, SyntaxKind.GE);
 
 	private ILogicalConditionCriteriaNode conditionCriteria() throws ParseError
 	{


### PR DESCRIPTION
added CIRCUMFLEX_EQUAL to the list of private static final Set<SyntaxKind> CONDITIONAL_OPERATOR_START