### PR TITLE
Fix first IExtendedRelationalCriteriaPartNode not having subnodes

### DIFF
--- a/libs/natls/src/test/java/org/amshove/natls/definition/DefinitionEndpointTests.java
+++ b/libs/natls/src/test/java/org/amshove/natls/definition/DefinitionEndpointTests.java
@@ -274,6 +274,25 @@ class DefinitionEndpointTests extends LanguageServerTest
 		);
 	}
 
+	@Test
+	void definitionShouldNotBreakAfterOrEquals()
+	{
+		assertSingleDefinitionInSameModule(
+			"""
+				DEFINE DATA LOCAL
+				1 #VAR (A10)
+				END-DEFINE
+
+				IF 5 = 5 OR = 6 OR = 8
+				WRITE #V${}$AR
+				END-IF
+
+				END
+				""",
+			1, 2
+		);
+	}
+
 	@Override
 	protected LspTestContext getContext()
 	{

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ExtendedRelationalCriteriaNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ExtendedRelationalCriteriaNode.java
@@ -19,6 +19,7 @@ class ExtendedRelationalCriteriaNode extends BaseSyntaxNode implements IExtended
 		left = relationalCriteriaNode.left();
 
 		var right = new ExtendedRelationalCriteriaPartNode();
+		right.copyFrom(relationalCriteriaNode);
 		right.setComparisonToken(relationalCriteriaNode.comparisonToken());
 		right.setRhs(relationalCriteriaNode.right());
 		addRight(right);


### PR DESCRIPTION
The first IExtendedRelationalCriteriaPartNode is constructed from a previous parsed condition. The subnodes of the conditions weren't appended to the newly constructed IExtendedRelationalCriteriaPartNode.