### PR TITLE
Load variable type info from DDMs

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -42,10 +42,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Cache SonarCloud packages
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -49,10 +49,10 @@ jobs:
           git checkout ${{ github.event.workflow_run.head_branch }}
           git clean -ffdx && git reset --hard HEAD
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
 
       - name: SonarCloud Scan on PR

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IVariableNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IVariableNode.java
@@ -21,6 +21,7 @@ public non-sealed interface IVariableNode extends IReferencableNode, IParameterD
 
 	default boolean isArray()
 	{
-		return dimensions() != null && dimensions().size() > 0;
+		var dimensions = dimensions();
+		return dimensions != null && !dimensions.isEmpty();
 	}
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataParser.java
@@ -1224,11 +1224,6 @@ public class DefineDataParser extends AbstractParser<IDefineData>
 
 	private void checkRedefineLength(IRedefinitionNode redefinitionNode)
 	{
-		if (redefinitionNode.isInView())
-		{
-			return;
-		}
-
 		var target = redefinitionNode.target();
 
 		if (target instanceof ITypedVariableNode typedTarget && typedTarget.type() == null)
@@ -1302,10 +1297,7 @@ public class DefineDataParser extends AbstractParser<IDefineData>
 				var groupLength = 0;
 				for (var member : groupNode.variables())
 				{
-					if (!member.isInView())
-					{
-						groupLength += calculateVariableLengthInBytes(member);
-					}
+					groupLength += calculateVariableLengthInBytes(member);
 				}
 
 				return groupLength;

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ParserErrors.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ParserErrors.java
@@ -215,6 +215,15 @@ class ParserErrors
 		);
 	}
 
+	public static ParserDiagnostic unresolvedDdmField(ITokenNode node)
+	{
+		return ParserDiagnostic.create(
+			"Unresolved DDM field: %s".formatted(node.token().source()),
+			node.token(),
+			ParserError.UNRESOLVED_REFERENCE
+		);
+	}
+
 	public static ParserDiagnostic arrayDimensionMustBeConstOrInitialized(ITokenNode token)
 	{
 		return ParserDiagnostic.create(

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ParserErrors.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ParserErrors.java
@@ -330,6 +330,15 @@ class ParserErrors
 		);
 	}
 
+	public static IDiagnostic unresolvedDdm(SyntaxToken token)
+	{
+		return ParserDiagnostic.create(
+			"Could not resolve DDM %s".formatted(token.symbolName()),
+			token,
+			ParserError.UNRESOLVED_IMPORT
+		);
+	}
+
 	public static IDiagnostic unresolvedExternalModule(SyntaxToken token)
 	{
 		return ParserDiagnostic.create(

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ParserErrors.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ParserErrors.java
@@ -217,8 +217,13 @@ class ParserErrors
 
 	public static ParserDiagnostic unresolvedDdmField(ITokenNode node)
 	{
+		return unresolvedDdmField(node, node.token().symbolName());
+	}
+
+	public static ParserDiagnostic unresolvedDdmField(ITokenNode node, String fieldName)
+	{
 		return ParserDiagnostic.create(
-			"Unresolved DDM field: %s".formatted(node.token().source()),
+			"Unresolved DDM field: %s".formatted(fieldName),
 			node.token(),
 			ParserError.UNRESOLVED_REFERENCE
 		);

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -315,7 +315,42 @@ class ViewParser extends AbstractParser<ViewNode>
 
 	private void checkVariableTypeAgainstDdm(TypedVariableNode typed)
 	{
-		// TODO
+		var ddmField = view.ddm().findField(typed.name());
+		if (ddmField == null)
+		{
+			return;
+		}
+
+		if (ddmField.format() == null || ddmField.format() == DataFormat.NONE)
+		{
+			return;
+		}
+
+		if (typed.type() == null)
+		{
+			// TODO: only dimensions specified?
+			return;
+		}
+
+		if (
+			(ddmField.format() == DataFormat.LOGIC && typed.type().format() == DataFormat.LOGIC)
+			|| (ddmField.format() == DataFormat.DATE && typed.type().format() == DataFormat.DATE)
+			|| (ddmField.format() == DataFormat.TIME && typed.type().format() == DataFormat.TIME)
+		)
+		{
+			// It would complain about length 0 (Natural) vs length 1 (Adabas)
+			return;
+		}
+
+		if (ddmField.format() != typed.type().format())
+		{
+			report(ParserErrors.typeMismatch("Type mismatch: Variable has format %s but DDM field has format %s".formatted(typed.type().format(), ddmField.format()), typed));
+		}
+
+		if (ddmField.length() != typed.type().length())
+		{
+			report(ParserErrors.typeMismatch("Type mismatch: Variable (format %s) has length %f but DDM field (format %s) has length %f".formatted(typed.type().format(), typed.type().length(), ddmField.format(), ddmField.length()), typed));
+		}
 	}
 
 	private double getLengthFromDataType(String dataType)

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -239,21 +239,28 @@ class ViewParser extends AbstractParser<ViewNode>
 		}
 
 		var typedVariable = new TypedVariableNode(variable);
-		var ddmField = view.ddm().findField(variable.name());
+
+		var isCountVariable = variable.name().startsWith("C*");
+		var fieldName = isCountVariable ? variable.name().substring(2) : variable.name();
+		var ddmField = view.ddm().findField(fieldName);
 
 		if (ddmField == null)
 		{
-			if (!variable.name().startsWith("C*"))
+			if (!isCountVariable)
 			{
 				report(ParserErrors.unresolvedDdmField(variable.identifierNode()));
-				return variable;
+			}
+			else
+			{
+				report(ParserErrors.unresolvedDdmField(variable.identifierNode(), fieldName));
 			}
 
-			var countType = new VariableType();
-			countType.setLength(4);
-			countType.setFormat(DataFormat.INTEGER);
-			typedVariable.setType(countType);
-			return typedVariable;
+			return variable;
+		}
+
+		if (isCountVariable)
+		{
+			return typedCountVariable(typedVariable);
 		}
 
 		if (ddmField.fieldType() == FieldType.GROUP)
@@ -274,6 +281,15 @@ class ViewParser extends AbstractParser<ViewNode>
 			typedVariable.addDimension(dimension);
 		}
 
+		return typedVariable;
+	}
+
+	private TypedVariableNode typedCountVariable(TypedVariableNode typedVariable)
+	{
+		var countType = new VariableType();
+		countType.setLength(4);
+		countType.setFormat(DataFormat.INTEGER);
+		typedVariable.setType(countType);
 		return typedVariable;
 	}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -286,7 +286,7 @@ class ViewParser extends AbstractParser<ViewNode>
 				{
 					var dimension = new ArrayDimension();
 					dimension.setLowerBound(1);
-					dimension.setUpperBound(IArrayDimension.UNBOUND_VALUE);
+					dimension.setUpperBound(199);
 					typedVariable.addDimension(dimension);
 					break;
 				}
@@ -297,7 +297,7 @@ class ViewParser extends AbstractParser<ViewNode>
 		{
 			var dimension = new ArrayDimension();
 			dimension.setLowerBound(1);
-			dimension.setUpperBound(IArrayDimension.UNBOUND_VALUE);
+			dimension.setUpperBound(199);
 			typedVariable.addDimension(dimension);
 		}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -240,7 +240,7 @@ class ViewParser extends AbstractParser<ViewNode>
 
 		if (ddmField == null)
 		{
-			// TODO: unresolved error
+			report(ParserErrors.unresolvedDdmField(variable.identifierNode()));
 			return variable;
 		}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -326,7 +326,6 @@ class ViewParser extends AbstractParser<ViewNode>
 
 		if (typed.type() == null)
 		{
-			// TODO: only dimensions specified?
 			return;
 		}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -45,6 +45,10 @@ class ViewParser extends AbstractParser<ViewNode>
 			{
 				var ddm = moduleProvider.findDdm(targetDdm.symbolName());
 				view.setDdm(ddm);
+				if (ddm == null && !targetDdm.symbolName().startsWith("&"))
+				{
+					report(ParserErrors.unresolvedDdm(targetDdm));
+				}
 			}
 
 			while (peekKind(SyntaxKind.NUMBER_LITERAL) && peek().intValue() > view.level())
@@ -206,7 +210,7 @@ class ViewParser extends AbstractParser<ViewNode>
 			group.addVariable(nestedVariable);
 		}
 
-		if (group.variables().size() == 0)
+		if (group.variables().isEmpty())
 		{
 			report(ParserErrors.emptyGroupVariable(group));
 		}
@@ -228,10 +232,9 @@ class ViewParser extends AbstractParser<ViewNode>
 	// Type is loaded from DDM.
 	private VariableNode typedVariableFromDdm(VariableNode variable)
 	{
-		// unresolved
+		// unresolved DDM
 		if (view.ddm() == null)
 		{
-			// TODO: unresolved error?
 			return variable;
 		}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -315,6 +315,11 @@ class ViewParser extends AbstractParser<ViewNode>
 
 	private void checkVariableTypeAgainstDdm(TypedVariableNode typed)
 	{
+		if (view.ddm() == null)
+		{
+			return;
+		}
+
 		var ddmField = view.ddm().findField(typed.name());
 		if (ddmField == null)
 		{
@@ -332,11 +337,9 @@ class ViewParser extends AbstractParser<ViewNode>
 			return;
 		}
 
-		if (
-			(ddmField.format() == DataFormat.LOGIC && typed.type().format() == DataFormat.LOGIC)
+		if ((ddmField.format() == DataFormat.LOGIC && typed.type().format() == DataFormat.LOGIC)
 			|| (ddmField.format() == DataFormat.DATE && typed.type().format() == DataFormat.DATE)
-			|| (ddmField.format() == DataFormat.TIME && typed.type().format() == DataFormat.TIME)
-		)
+			|| (ddmField.format() == DataFormat.TIME && typed.type().format() == DataFormat.TIME))
 		{
 			// It would complain about length 0 (Natural) vs length 1 (Adabas)
 			return;

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -240,8 +240,17 @@ class ViewParser extends AbstractParser<ViewNode>
 
 		if (ddmField == null)
 		{
-			report(ParserErrors.unresolvedDdmField(variable.identifierNode()));
-			return variable;
+			if (!variable.name().startsWith("C*"))
+			{
+				report(ParserErrors.unresolvedDdmField(variable.identifierNode()));
+				return variable;
+			}
+
+			var countType = new VariableType();
+			countType.setLength(4);
+			countType.setFormat(DataFormat.INTEGER);
+			typedVariable.setType(countType);
+			return typedVariable;
 		}
 
 		if (ddmField.fieldType() == FieldType.GROUP)

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/DdmParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/DdmParser.java
@@ -77,7 +77,8 @@ public class DdmParser
 			}
 
 			var field = parseField(scanner);
-			if (field.fieldType() == FieldType.GROUP || field.fieldType() == FieldType.PERIODIC)
+			if ((field.fieldType() == FieldType.GROUP || field.fieldType() == FieldType.PERIODIC)
+				&& field.descriptor() != DescriptorType.SUPERDESCRIPTOR)
 			{
 				var groupField = new GroupField(field);
 				scanner.advance();

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/DdmParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/DdmParser.java
@@ -77,7 +77,7 @@ public class DdmParser
 			}
 
 			var field = parseField(scanner);
-			if (field.fieldType() == FieldType.GROUP)
+			if (field.fieldType() == FieldType.GROUP || field.fieldType() == FieldType.PERIODIC)
 			{
 				var groupField = new GroupField(field);
 				scanner.advance();

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/FieldParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/FieldParser.java
@@ -47,10 +47,10 @@ class FieldParser
 		var descriptorType = parseDescriptorType(fieldLine);
 		var remark = parseRemark(fieldLine);
 
-		var length = fieldType == FieldType.GROUP || fieldType == FieldType.PERIODIC
+		var length = descriptorType == DescriptorType.NONE && (fieldType == FieldType.GROUP || fieldType == FieldType.PERIODIC)
 			? 0
 			: parseLength(scanner);
-		var dataFormat = fieldType == FieldType.GROUP || fieldType == FieldType.PERIODIC
+		var dataFormat = descriptorType == DescriptorType.NONE && (fieldType == FieldType.GROUP || fieldType == FieldType.PERIODIC)
 			? DataFormat.NONE
 			: parseFormat(fieldLine);
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/GroupField.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ddm/GroupField.java
@@ -13,7 +13,7 @@ class GroupField extends DdmField implements IGroupField
 	GroupField(DdmField field)
 	{
 		super(field);
-		if (field.fieldType() != FieldType.GROUP)
+		if (field.fieldType() != FieldType.GROUP && field.fieldType() != FieldType.PERIODIC)
 		{
 			throw new NaturalParseException(String.format("Cannot promote field of type %s to GroupField", field.fieldType()));
 		}

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -1280,7 +1280,7 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 
 		var view = findVariable(defineData, "MY-VIEW", IViewNode.class);
 		assertThat(view.variables().size()).isEqualTo(1);
-		var theArray = assertNodeType(view.variables().first(), ITypedVariableNode.class);
+		var theArray = assertNodeType(view.variables().first(), VariableNode.class);
 		assertThat(theArray.name()).isEqualTo("ARRAY-INSIDE");
 		assertThat(theArray.dimensions().first().lowerBound()).isEqualTo(1);
 		assertThat(theArray.dimensions().first().upperBound()).isEqualTo(8);
@@ -1301,7 +1301,7 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 
 		var view = assertNodeType(defineData.variables().first(), IViewNode.class);
 		assertThat(view.variables().size()).isEqualTo(1);
-		var theArray = assertNodeType(view.variables().first(), TypedVariableNode.class);
+		var theArray = assertNodeType(view.variables().first(), VariableNode.class);
 		assertThat(theArray.name()).isEqualTo("DDM-FIELD");
 		assertThat(theArray.dimensions().first().lowerBound()).isEqualTo(1);
 		assertThat(theArray.dimensions().first().upperBound()).isEqualTo(10);
@@ -2157,6 +2157,44 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 		assertThat(periodicMember.dimensions()).hasSize(1);
 		assertThat(periodicMember.dimensions().first().lowerBound()).isEqualTo(1);
 		assertThat(periodicMember.dimensions().first().upperBound()).isEqualTo(10);
+	}
+
+	@Test
+	void useArrayDimensionsOfPeriodicMembersWhenExplicitlySpecified()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		var defineData = assertParsesWithoutDiagnostics("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+				2 A-PERIODIC-MEMBER (1)
+			END-DEFINE
+			""");
+
+		var periodicMember = assertNodeType(defineData.findVariable("A-PERIODIC-MEMBER"), ITypedVariableNode.class);
+		assertThat(periodicMember.dimensions()).hasSize(1);
+		assertThat(periodicMember.dimensions().first().lowerBound()).isEqualTo(1);
+		assertThat(periodicMember.dimensions().first().upperBound()).isEqualTo(1);
+	}
+
+	@Test
+	void useArrayDimensionsOfMultipleValueFieldsWhenExplicitlySpecifiedButWithoutType()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		var defineData = assertParsesWithoutDiagnostics("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+				2 A-MULTIPLE-FIELD (1:10)
+			END-DEFINE
+			""");
+
+		var field = assertNodeType(defineData.findVariable("A-MULTIPLE-FIELD"), ITypedVariableNode.class);
+		assertThat(field.type().format()).isEqualTo(DataFormat.NUMERIC);
+		assertThat(field.type().length()).isEqualTo(7.2);
+		assertThat(field.dimensions()).hasSize(1);
+		assertThat(field.dimensions().first().lowerBound()).isEqualTo(1);
+		assertThat(field.dimensions().first().upperBound()).isEqualTo(10);
 	}
 
 	@Test

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -5,7 +5,6 @@ import org.amshove.natparse.natural.*;
 import org.amshove.natparse.natural.ddm.FieldType;
 import org.amshove.natparse.natural.ddm.IDataDefinitionModule;
 import org.amshove.natparse.natural.ddm.IDdmField;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
@@ -2062,6 +2061,7 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 			1 MY-VIEW VIEW OF MY-DDM
 			2 A-DDM-FIELD
 			2 A-MULTIPLE-FIELD
+			2 C*A-MULTIPLE-FIELD
 			END-DEFINE
 			""");
 
@@ -2074,6 +2074,10 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 		assertThat(ddmMultipleValueField.type().length()).isEqualTo(7.2);
 		assertThat(ddmMultipleValueField.dimensions().first().lowerBound()).isEqualTo(1);
 		assertThat(ddmMultipleValueField.dimensions().first().isUpperUnbound()).isTrue();
+
+		var countField = assertNodeType(defineData.findVariable("C*A-MULTIPLE-FIELD"), ITypedVariableNode.class);
+		assertThat(countField.type().format()).isEqualTo(DataFormat.INTEGER);
+		assertThat(countField.type().length()).isEqualTo(4);
 	}
 
 	private <T extends IParameterDefinitionNode> void assertParameter(IParameterDefinitionNode node, Class<T> parameterType, String identifier)

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -2119,6 +2119,19 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 			""", ParserError.UNRESOLVED_REFERENCE);
 	}
 
+	@Test
+	void reportADiagnosticForUnresolvedCountFields()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		assertDiagnostic("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+			2 C*UNRESOLVED-FIELD
+			END-DEFINE
+			""", ParserError.UNRESOLVED_REFERENCE);
+	}
+
 	private <T extends IParameterDefinitionNode> void assertParameter(IParameterDefinitionNode node, Class<T> parameterType, String identifier)
 	{
 		var typedNode = assertNodeType(node, parameterType);

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -2052,6 +2052,32 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 	}
 
 	@Test
+	void reportADiagnosticForAnUnresolvableDdm()
+	{
+		useStubModuleProvider();
+		assertDiagnostic("""
+			DEFINE DATA
+			LOCAL
+			1 AVIEW VIEW OF UNRESOLVED
+			2 DDM-VAR
+			END-DEFINE
+			""", ParserError.UNRESOLVED_IMPORT);
+	}
+
+	@Test
+	void notReportADiagnosticForAnUnresolvableDdmCopycodeParameter()
+	{
+		useStubModuleProvider();
+		assertParsesWithoutDiagnostics("""
+			DEFINE DATA
+			LOCAL
+			1 AVIEW VIEW OF &1&
+			2 DDM-VAR
+			END-DEFINE
+			""");
+	}
+
+	@Test
 	void loadVariableTypesFromDdms()
 	{
 		useStubModuleProvider();

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -2223,6 +2223,58 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 			""", ParserError.UNRESOLVED_REFERENCE);
 	}
 
+	@Test
+	void reportADiagnosticIfASpecifiedVariableTypeDiffersFromTheDdmInFormat()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		assertDiagnostic("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+			2 A-DDM-FIELD (N10)
+			END-DEFINE
+			""", ParserError.TYPE_MISMATCH);
+	}
+
+	@Test
+	void reportADiagnosticIfASpecifiedVariableTypeDiffersFromTheDdmInLength()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		assertDiagnostic("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+			2 A-DDM-FIELD (A8)
+			END-DEFINE
+			""", ParserError.TYPE_MISMATCH);
+	}
+
+	@Test
+	void notReportADiagnosticIfASpecifiedVariableTypeDiffersInLengthSpecificationForDateVariables()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		assertParsesWithoutDiagnostics("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+			2 DATE-FIELD (D)
+			END-DEFINE
+			""");
+	}
+
+	@Test
+	void notReportADiagnosticIfASpecifiedVariableTypeDiffersInLengthSpecificationForLogicalVariables()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		assertParsesWithoutDiagnostics("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+			2 BOOL-FIELD (L)
+			END-DEFINE
+			""");
+	}
+
 	private <T extends IParameterDefinitionNode> void assertParameter(IParameterDefinitionNode node, Class<T> parameterType, String identifier)
 	{
 		var typedNode = assertNodeType(node, parameterType);
@@ -2281,6 +2333,8 @@ T L DB Name                              F Leng  S D Remark
 M 1 AC A-MULTIPLE-FIELD                  N  7,2  N
 P 1 BA A-PERIODIC-GROUP
   2 BB A-PERIODIC-MEMBER                 A    5  N
+  1 CA DATE-FIELD                        D    6  N
+  1 CB BOOL-FIELD                        L    1  N
   1 AG A-SUPERDESCRIPTOR                 A   25  N S
 *      -------- SOURCE FIELD(S) -------
 *      A-DDM-FIELD   (1-10)

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -2106,6 +2106,19 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 		assertThat(countField.type().length()).isEqualTo(4);
 	}
 
+	@Test
+	void reportADiagnosticForUnresolvedDdmFields()
+	{
+		useStubModuleProvider();
+		moduleProvider.addDdm("MY-DDM", myDdm());
+		assertDiagnostic("""
+			DEFINE DATA LOCAL
+			1 MY-VIEW VIEW OF MY-DDM
+			2 UNRESOLVED-FIELD
+			END-DEFINE
+			""", ParserError.UNRESOLVED_REFERENCE);
+	}
+
 	private <T extends IParameterDefinitionNode> void assertParameter(IParameterDefinitionNode node, Class<T> parameterType, String identifier)
 	{
 		var typedNode = assertNodeType(node, parameterType);

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -2102,7 +2102,7 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 		assertThat(ddmMultipleValueField.type().format()).isEqualTo(DataFormat.NUMERIC);
 		assertThat(ddmMultipleValueField.type().length()).isEqualTo(7.2);
 		assertThat(ddmMultipleValueField.dimensions().first().lowerBound()).isEqualTo(1);
-		assertThat(ddmMultipleValueField.dimensions().first().isUpperUnbound()).isTrue();
+		assertThat(ddmMultipleValueField.dimensions().first().upperBound()).isEqualTo(199);
 
 		var countField = assertNodeType(defineData.findVariable("C*A-MULTIPLE-FIELD"), ITypedVariableNode.class);
 		assertThat(countField.type().format()).isEqualTo(DataFormat.INTEGER);
@@ -2112,7 +2112,7 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 		assertThat(periodicMember.type().format()).isEqualTo(DataFormat.ALPHANUMERIC);
 		assertThat(periodicMember.type().length()).isEqualTo(5.0);
 		assertThat(periodicMember.dimensions().first().lowerBound()).isEqualTo(1);
-		assertThat(periodicMember.dimensions().first().isUpperUnbound()).isTrue();
+		assertThat(periodicMember.dimensions().first().upperBound()).isEqualTo(199);
 	}
 
 	@Test

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/ModuleProviderStub.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/ModuleProviderStub.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public class ModuleProviderStub implements IModuleProvider
 {
 	private final Map<String, INaturalModule> referableModules = new HashMap<>();
+	private final Map<String, IDataDefinitionModule> ddms = new HashMap<>();
 
 	public ModuleProviderStub addModule(String referableName, INaturalModule module)
 	{
@@ -25,6 +26,11 @@ public class ModuleProviderStub implements IModuleProvider
 	@Override
 	public IDataDefinitionModule findDdm(String referableName)
 	{
-		return null;
+		return ddms.get(referableName);
+	}
+
+	public void addDdm(String ddmName, IDataDefinitionModule ddm)
+	{
+		ddms.put(ddmName, ddm);
 	}
 }

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/ddm/DdmParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/ddm/DdmParserShould.java
@@ -145,6 +145,33 @@ class DdmParserShould
 	}
 
 	@Test
+	void parseASuperdescriptorThatIsAlsoAPeriodicGroup()
+	{
+		var ddm = new DdmParser().parseDdm("""
+DB: 000 FILE: 100  - MY-DDM                      DEFAULT SEQUENCE:
+TYPE: ADABAS
+
+T L DB Name                              F Leng  S D Remark
+- - -- --------------------------------  - ----  - - ------------------------
+  1 AA A-DDM-FIELD                       A   10  N
+  1 AB ANOTHER-DDM-FIELD                 A   15  N
+M 1 AC A-MULTIPLE-FIELD                  N  7,2  N
+P 1 BA A-PERIODIC-GROUP
+  2 BB A-PERIODIC-MEMBER                 A    5  N
+P 1 AG A-SUPERDESCRIPTOR                 A   25  N S
+*      -------- SOURCE FIELD(S) -------
+*      A-DDM-FIELD   (1-10)
+*      ANOTHER-DDM-FIELD (1-15)
+			""");
+
+		var descriptor = findField(ddm, "A-SUPERDESCRIPTOR");
+		assertThat(descriptor.format()).isEqualTo(DataFormat.ALPHANUMERIC);
+		assertThat(descriptor.length()).isEqualTo(25);
+		assertThat(descriptor.descriptor()).isEqualTo(DescriptorType.SUPERDESCRIPTOR);
+		assertThat(descriptor.fieldType()).isEqualTo(FieldType.PERIODIC);
+	}
+
+	@Test
 	void throwAnExceptionIfNoMatchingFieldToReferenceIsFound()
 	{
 		assertThatExceptionOfType(NaturalParseException.class)

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/ddm/DdmParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/ddm/DdmParserShould.java
@@ -48,12 +48,12 @@ class DdmParserShould
 		assertThat(ddm.name()).isEqualTo("COMPLETE-DDM");
 		assertThat(ddm.fileNumber()).isEqualTo("100");
 		assertThat(ddm.databaseNumber()).isEqualTo("000");
-		assertThat(ddm.defaultSequence()).isEqualTo("");
+		assertThat(ddm.defaultSequence()).isEmpty();
 		assertThat(ddm.type()).isEqualTo(DdmType.ADABAS);
 
 		var fields = ddm.fields();
 
-		assertThat(ddm.fields().size()).isEqualTo(11);
+		assertThat(ddm.fields()).hasSize(12);
 		var topLevelFields = fields.stream().map(IDdmField::name).collect(Collectors.toList());
 
 		assertThat(topLevelFields)
@@ -80,6 +80,14 @@ class DdmParserShould
 		var nestedGroup = assertIsGroupField(findGroupMember(topLevelGroupField, "TOP-LEVEL-GROUP-GROUP"));
 		assertThat(nestedGroup.level()).isEqualTo(2);
 		assertGroupHasMember(nestedGroup, "TOP-LEVEL-GROUP-GROUP-CHILD");
+
+		var periodicGroup = assertIsPeriodicGroupField(findField(ddm, "PERIODIC-GROUP"));
+		assertThat(periodicGroup.fieldType()).isEqualTo(FieldType.PERIODIC);
+		assertGroupHasMember(periodicGroup, "PERIODIC-MEMBER");
+		var periodicMember = findGroupMember(periodicGroup, "PERIODIC-MEMBER");
+		assertThat(periodicMember.level()).isEqualTo(2);
+		assertThat(periodicMember.format()).isEqualTo(DataFormat.NUMERIC);
+		assertThat(periodicMember.length()).isEqualTo(2.0);
 
 		var aSuperdescriptor = assertIsSuperdescriptor(findField(ddm, "A-SUPERDESCRIPTOR"));
 		assertThat(aSuperdescriptor.fields()).hasSize(2);
@@ -173,6 +181,13 @@ class DdmParserShould
 	private IGroupField assertIsGroupField(IDdmField field)
 	{
 		assertThat(field.fieldType()).isEqualTo(FieldType.GROUP);
+		assertThat(field).isInstanceOf(IGroupField.class);
+		return (IGroupField) field;
+	}
+
+	private IGroupField assertIsPeriodicGroupField(IDdmField field)
+	{
+		assertThat(field.fieldType()).isEqualTo(FieldType.PERIODIC);
 		assertThat(field).isInstanceOf(IGroupField.class);
 		return (IGroupField) field;
 	}

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/ddm/DdmParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/ddm/DdmParserShould.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
-public class DdmParserShould
+class DdmParserShould
 {
 	@Test
 	void parseTheMetadataLine()

--- a/libs/natparse/src/test/resources/org/amshove/natparse/parsing/ddm/CompleteDdm.NSD
+++ b/libs/natparse/src/test/resources/org/amshove/natparse/parsing/ddm/CompleteDdm.NSD
@@ -22,6 +22,8 @@ G 1 GA TOP-LEVEL-GROUP                   N    7  N
   2 GB TOP-LEVEL-GROUP-CHILD             N   12  N
 G 2 GC TOP-LEVEL-GROUP-GROUP             N    5  N
   3 GD TOP-LEVEL-GROUP-GROUP-CHILD       N    5  N
+P 1 BA PERIODIC-GROUP
+  2 BB PERIODIC-MEMBER                   N    2  N
   1 AG A-SUPERDESCRIPTOR                 A   20  N S
 *      -------- SOURCE FIELD(S) -------
 *      ALPHA-FIELD   (1-8)


### PR DESCRIPTION
closes #15
closes #190
closes #338

- [x] If the data type length in the view is different than the one in the DDM, report a diagnostic. Do this only if data format is the same.
- [x] Look how many diagnostics arise when the whole data type differs
- [x] If the DDM is not resolvable, report a diagnostic
- [x] If the DDM field is not resolvable from the view variable, report a diagnostic
- [x] Add array bounds for multiple value fields
- [x] Add array bounds for periodic groups
- [x] Allow `C*FIELD` variables with type (I4 probably?)
- [x] Check on `C*FIELD` if `FIELD` exists on DDM
- [x] Allow redefinition of superdescriptors
- [x] Allow REDEFINE of the view/Remove exclusion from REDEFINE from views in `DataDefinitionParser::checkRedefineLength()`
- [x] Look for `isInView()` usages and see if they now can be solved
- [x] Handle variables that only have dimensions explicitly specified, not the data type