### PR TITLE
COMMA can also be used as array access separator for labels

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
@@ -1005,8 +1005,8 @@ abstract class AbstractParser<T>
 		{
 			consumeMandatory(reference, SyntaxKind.LPAREN);
 			var isArrayRef = consumeOptionally(reference, SyntaxKind.LABEL_IDENTIFIER)
-			&& (consumeOptionally(reference, SyntaxKind.SLASH)
-			|| consumeOptionally(reference, SyntaxKind.COMMA));
+				&& (consumeOptionally(reference, SyntaxKind.SLASH)
+					|| consumeOptionally(reference, SyntaxKind.COMMA));
 			// If just RPAREN left, then this was just a LABEL_IDENTIFIER and thus not an array.
 			isArrayRef = isArrayRef || !peekKind(SyntaxKind.RPAREN);
 			if (isArrayRef)

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
@@ -1004,7 +1004,9 @@ abstract class AbstractParser<T>
 		if (peekKind(SyntaxKind.LPAREN) && !getKind(1).isAttribute())
 		{
 			consumeMandatory(reference, SyntaxKind.LPAREN);
-			var isArrayRef = consumeOptionally(reference, SyntaxKind.LABEL_IDENTIFIER) && consumeOptionally(reference, SyntaxKind.SLASH);
+			var isArrayRef = consumeOptionally(reference, SyntaxKind.LABEL_IDENTIFIER)
+			&& (consumeOptionally(reference, SyntaxKind.SLASH)
+			|| consumeOptionally(reference, SyntaxKind.COMMA));
 			// If just RPAREN left, then this was just a LABEL_IDENTIFIER and thus not an array.
 			isArrayRef = isArrayRef || !peekKind(SyntaxKind.RPAREN);
 			if (isArrayRef)

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/OperandParsingTests.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/OperandParsingTests.java
@@ -641,7 +641,7 @@ class OperandParsingTests extends AbstractParserTest<IStatementListNode>
 	}
 
 	@Test
-	void doParsePossibleNumberedLabelReferencesAsArrayIndex()
+	void parsePossibleNumberedLabelReferencesAsArrayIndex()
 	{
 		var operand = parseOperand("#ARR(0123)");
 		var reference = assertIsVariableReference(operand, "#ARR");

--- a/libs/natparse/src/test/resources/org/amshove/natparse/parsing/typing/arrayAccessTests
+++ b/libs/natparse/src/test/resources/org/amshove/natparse/parsing/typing/arrayAccessTests
@@ -20,6 +20,8 @@ WRITE #NOT-ARRAY(HIS.) /* No diagnostic, label reference
 /* No diagnostics, array accessed
 WRITE #ARR(*)
 WRITE #ARR(5)
+WRITE #ARR(LABEL./1)
+WRITE #ARR(LABEL.,2)
 
 /* No dimension specified
 WRITE #ARR /* !{D:ERROR:NPP042}


### PR DESCRIPTION
@MarkusAmshove This fixes 1100+ diagnostics for me, please check your side. 