### PR TITLE
Use go to definition to jump between opening and closing statement keywords

### DIFF
--- a/libs/natls/src/main/java/org/amshove/natls/languageserver/LspUtil.java
+++ b/libs/natls/src/main/java/org/amshove/natls/languageserver/LspUtil.java
@@ -136,7 +136,7 @@ public class LspUtil
 	public static Location toLocation(ISyntaxNode node)
 	{
 		var position = node.position();
-		return toLocation(position, node.descendants().last().position());
+		return toLocation(position, node.descendants().hasItems() ? node.descendants().last().position() : position);
 	}
 
 	public static Location toLocation(IPosition position)

--- a/libs/natls/src/main/java/org/amshove/natls/languageserver/NaturalLanguageService.java
+++ b/libs/natls/src/main/java/org/amshove/natls/languageserver/NaturalLanguageService.java
@@ -245,6 +245,16 @@ public class NaturalLanguageService implements LanguageClientAware
 			return List.of(LspUtil.toLocation(moduleReferencingNode.reference()));
 		}
 
+		if (node.token() != null && node.token().kind().opensStatement())
+		{
+			return List.of(LspUtil.toLocation(node.parent().descendants().last()));
+		}
+
+		if (node.token() != null && node.token().kind().closesStatement())
+		{
+			return List.of(LspUtil.toLocation(node.parent().descendants().first()));
+		}
+
 		return List.of();
 	}
 

--- a/libs/natls/src/test/java/org/amshove/natls/definition/DefinitionEndpointTests.java
+++ b/libs/natls/src/test/java/org/amshove/natls/definition/DefinitionEndpointTests.java
@@ -179,10 +179,38 @@ class DefinitionEndpointTests extends LanguageServerTest
 	void definitionShouldReturnAnEmptyListIfCalledOnAKeyword()
 	{
 		assertNoDefinitions("""
-			DEF${}$INE DATA LOCAL
+			DEFINE DA${}$TA LOCAL
 			END-DEFINE
 			END
 			""");
+	}
+
+	@Test
+	void definitionShouldReturnEndTokenForStatementOpeningKeywords()
+	{
+		assertSingleDefinitionInSameModule(
+			"""
+			DEF${}$INE DATA LOCAL
+			END-DEFINE
+			END
+			""",
+			1, // END-DEFINE
+			0
+		);
+	}
+
+	@Test
+	void definitionShouldReturnOpeningTokenForStatementClosingKeywords()
+	{
+		assertSingleDefinitionInSameModule(
+			"""
+			DEFINE DATA LOCAL
+			E${}$ND-DEFINE
+			END
+			""",
+			0, // DEFINE
+			0
+		);
 	}
 
 	@Test

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
@@ -820,4 +820,14 @@ public enum SyntaxKind
 			this == UC ||
 			this == ZP;
 	}
+
+	public boolean closesStatement()
+	{
+		return this == END_IF || this == END_FOR || this == END_DECIDE || this == END_DEFINE || this == END_BREAK || this == END_ERROR || this == END_FIND || this == END_READ || this == END_SUBROUTINE || this == END_REPEAT || this == END_WORK;
+	}
+
+	public boolean opensStatement()
+	{
+		return this == IF || this == DEFINE || this == DECIDE || this == REPEAT || this == READ || this == FIND || this == FOR;
+	}
 }


### PR DESCRIPTION
With this change, `go to definition` can be used to jump between opening and closing tokens of a statement.

For example, if it is triggered on `END-IF`, it will jump to the corresponding `IF` keyword.