### PR TITLE
Translate token kinds in diagnostics to keywords

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
@@ -836,4 +836,10 @@ public enum SyntaxKind
 	{
 		return this == IF || this == DEFINE || this == DECIDE || this == REPEAT || this == READ || this == FIND || this == FOR;
 	}
+
+	@Override
+	public String toString()
+	{
+		return name().replace("SV_", "*").replace("KW_", "").replace("_", "-");
+	}
 }


### PR DESCRIPTION
This will rename things like `END_SUBROUTINE` (the enum member) to `END-SUBROUTINE`

closes #484 