### PR TITLE
Fix go-to-references inside Copycodes

### DIFF
--- a/libs/natls/src/main/java/org/amshove/natls/referencing/ReferenceFinder.java
+++ b/libs/natls/src/main/java/org/amshove/natls/referencing/ReferenceFinder.java
@@ -57,7 +57,8 @@ public class ReferenceFinder
 			);
 		}
 
-		if (node != null && node.parent() instanceof IStatementListNode && node.parent().parent() == null && file.getType() == NaturalFileType.COPYCODE)
+		var filetype = file.getType();
+		if (references.isEmpty() && filetype == NaturalFileType.COPYCODE)
 		{
 			// We're on the very first node within a copy code, so we're looking for references to the copy code
 			for (var callingFile : file.getIncomingReferences())

--- a/libs/natls/src/test/java/org/amshove/natls/references/FindReferencesTests.java
+++ b/libs/natls/src/test/java/org/amshove/natls/references/FindReferencesTests.java
@@ -73,7 +73,7 @@ class FindReferencesTests extends LanguageServerTest
 					return dynamicTest(
 						"%d:%d -> %s:%d:%d".formatted(rT.line, rT.col, ref.modulename, ref.line, ref.col),
 						() -> assertThat(references)
-							.as("No given reference matches expected location")
+							.as("No given reference matches expected location %d:%d in %s".formatted(ref.line, ref.col, ref.modulename))
 							.anyMatch(
 								l -> l.getUri().equals(theModule.file().getPath().toUri().toString())
 									&& l.getRange().getStart().getLine() == ref.line

--- a/libs/natls/src/test/resources/projects/findreferences/Natural-Libraries/LIBONE/CCODE.NSC
+++ b/libs/natls/src/test/resources/projects/findreferences/Natural-Libraries/LIBONE/CCODE.NSC
@@ -1,5 +1,5 @@
 * >Natural Source Header 000000
-* :Mode S
+* :Mode S /* !ref(0){SUB,4,8;SUB,6,8}
 * :CP
-* <Natural Source Header
+* <Natural Source Header /* !ref(0){SUB,4,8;SUB,6,8}
 IGNORE /* !ref(0){SUB,4,8;SUB,6,8}


### PR DESCRIPTION
This will correctly point to the INCLUDE position again