### PR TITLE
Do not treat double quotes as begin of string in edit masks

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
@@ -1212,7 +1212,7 @@ public class Lexer
 				nestedParens--;
 			}
 
-			if (scanner.peek() == '\'' || scanner.peek() == '"')
+			if (scanner.peek() == '\'')
 			{
 				isInString = !isInString;
 			}

--- a/libs/natparse/src/test/java/org/amshove/natparse/lexing/LexerForAttributeControlsShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/lexing/LexerForAttributeControlsShould.java
@@ -97,6 +97,28 @@ class LexerForAttributeControlsShould extends AbstractLexerTest
 	}
 
 	@Test
+	void treatDoubleQuotesInEditMasksAtStartLiterally()
+	{
+		assertTokens(
+			"(EM=\"Q999)",
+			token(SyntaxKind.LPAREN),
+			token(SyntaxKind.EM, "EM=\"Q999"),
+			token(SyntaxKind.RPAREN)
+		);
+	}
+
+	@Test
+	void treatDoubleQuotesInEditMasksAnywhereLiterally()
+	{
+		assertTokens(
+			"(EM=99\"9\"9)",
+			token(SyntaxKind.LPAREN),
+			token(SyntaxKind.EM, "EM=99\"9\"9"),
+			token(SyntaxKind.RPAREN)
+		);
+	}
+
+	@Test
 	void recognizeEmWhenFollowingAnIdentifier()
 	{
 		assertTokens(


### PR DESCRIPTION
fixes #537 