### PR TITLE
Implement copycode name completions

### DIFF
--- a/libs/natls/src/main/java/org/amshove/natls/completion/CodeCompletionContext.java
+++ b/libs/natls/src/main/java/org/amshove/natls/completion/CodeCompletionContext.java
@@ -63,6 +63,11 @@ public record CodeCompletionContext(
 		return isCurrentTokenKind(SyntaxKind.PERFORM) || isPreviousTokenKind(SyntaxKind.PERFORM);
 	}
 
+	public boolean completesInclude()
+	{
+		return isCurrentTokenKind(SyntaxKind.INCLUDE) || isPreviousTokenKind(SyntaxKind.INCLUDE);
+	}
+
 	public boolean completesCallnat()
 	{
 		return isCurrentTokenKind(SyntaxKind.CALLNAT) || isPreviousTokenKind(SyntaxKind.CALLNAT);

--- a/libs/natls/src/main/java/org/amshove/natls/completion/CompletionProvider.java
+++ b/libs/natls/src/main/java/org/amshove/natls/completion/CompletionProvider.java
@@ -56,6 +56,12 @@ public class CompletionProvider
 		{
 			return dataAreaCompletions(file.getLibrary());
 		}
+		
+		if (completionContext.completesInclude())
+		{
+			completionItems.addAll(copycodeCompletions(file.getLibrary(), completionContext));
+			return completionItems;
+		}
 
 		var isTriggeredByDot = params.getContext().getTriggerKind() == CompletionTriggerKind.TriggerCharacter && ".".equals(
 			params.getContext().getTriggerCharacter()
@@ -76,6 +82,7 @@ public class CompletionProvider
 			completionItems.addAll(localSubroutineCompletions(module, completionContext));
 			return completionItems;
 		}
+		
 
 		if (completionContext.completesCallnat() && !completionContext.completesParameter())
 		{
@@ -732,6 +739,31 @@ public class CompletionProvider
 				catch (Exception e)
 				{
 					log.log(Level.SEVERE, "Subprogram completion threw an exception", e);
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.toList();
+	}
+
+	private Collection<? extends CompletionItem> copycodeCompletions(
+		LanguageServerLibrary library,
+		CodeCompletionContext context
+	)
+	{
+		return library.getModulesOfType(NaturalFileType.COPYCODE, true)
+			.stream()
+			.map(f ->
+			{
+				try {
+					var item = new CompletionItem(f.getReferableName());
+					item.setInsertText(f.getReferableName());
+					item.setKind(CompletionItemKind.Module);
+					return item;
+				}
+				catch (Exception e)
+				{
+					log.log(Level.SEVERE, "Copycode completion threw an exception", e);
 					return null;
 				}
 			})

--- a/libs/natls/src/main/java/org/amshove/natls/completion/CompletionProvider.java
+++ b/libs/natls/src/main/java/org/amshove/natls/completion/CompletionProvider.java
@@ -56,7 +56,7 @@ public class CompletionProvider
 		{
 			return dataAreaCompletions(file.getLibrary());
 		}
-		
+
 		if (completionContext.completesInclude())
 		{
 			completionItems.addAll(copycodeCompletions(file.getLibrary(), completionContext));
@@ -82,7 +82,6 @@ public class CompletionProvider
 			completionItems.addAll(localSubroutineCompletions(module, completionContext));
 			return completionItems;
 		}
-		
 
 		if (completionContext.completesCallnat() && !completionContext.completesParameter())
 		{
@@ -755,7 +754,8 @@ public class CompletionProvider
 			.stream()
 			.map(f ->
 			{
-				try {
+				try
+				{
 					var item = new CompletionItem(f.getReferableName());
 					item.setInsertText(f.getReferableName());
 					item.setKind(CompletionItemKind.Module);

--- a/libs/natls/src/test/java/org/amshove/natls/completion/ExternalModuleCompletionShould.java
+++ b/libs/natls/src/test/java/org/amshove/natls/completion/ExternalModuleCompletionShould.java
@@ -464,4 +464,29 @@ class ExternalModuleCompletionShould extends CompletionTest
 			.assertContains("SUBN2", CompletionItemKind.Class)
 			.assertContainsOnlyKinds(CompletionItemKind.Class);
 	}
+	
+	@Test
+	void onlyContainCopycodesWhenInvokedAfterInclude()
+	{
+		createOrSaveFile("LIBONE", "SUBN.NSN", """
+			DEFINE DATA PARAMETER
+			1 #P-PARAM (A10)
+			END-DEFINE
+			END
+			""");
+		createOrSaveFile("LIBONE", "CPYC.NSC", """
+			WRITE "Copycodes are just compiled verbatim into your program"
+			""");
+		
+		assertCompletions("LIBONE", "PROG1.NSP", """
+			DEFINE DATA LOCAL
+			01 #LANGUAGE (A7)
+			END-DEFINE
+			IGNORE
+			INCLUDE ${}$
+			END
+			""")
+			.assertContains("CPYC", CompletionItemKind.Module)
+			.assertContainsOnlyKinds(CompletionItemKind.Module);
+	}
 }

--- a/libs/natls/src/test/java/org/amshove/natls/completion/ExternalModuleCompletionShould.java
+++ b/libs/natls/src/test/java/org/amshove/natls/completion/ExternalModuleCompletionShould.java
@@ -464,7 +464,7 @@ class ExternalModuleCompletionShould extends CompletionTest
 			.assertContains("SUBN2", CompletionItemKind.Class)
 			.assertContainsOnlyKinds(CompletionItemKind.Class);
 	}
-	
+
 	@Test
 	void onlyContainCopycodesWhenInvokedAfterInclude()
 	{
@@ -477,7 +477,7 @@ class ExternalModuleCompletionShould extends CompletionTest
 		createOrSaveFile("LIBONE", "CPYC.NSC", """
 			WRITE "Copycodes are just compiled verbatim into your program"
 			""");
-		
+
 		assertCompletions("LIBONE", "PROG1.NSP", """
 			DEFINE DATA LOCAL
 			01 #LANGUAGE (A7)


### PR DESCRIPTION
`INCLUDE` is always followed by a copycode module name parameter

(this was completing with a bunch of subroutines etc)