### PR TITLE
Add PDA structure analyzer for IN/OUT groups (NL041)

### DIFF
--- a/docs/analyzer-config.md
+++ b/docs/analyzer-config.md
@@ -16,6 +16,7 @@ The following configurations can be set in a `.editorconfig` file to configure p
 | `natls.style.discourage_hidden_dbms`          | `true`, `false` | [`NL035`](../tools/ruletranslator/src/main/resources/rules/NL035)|
 | `natls.style.discourage_long_literals`        | `true`, `false` | [`NL038`](../tools/ruletranslator/src/main/resources/rules/NL038)|
 | `natls.style.discourage_lowercase_code`       | `true`, `false` | [`NL039`](../tools/ruletranslator/src/main/resources/rules/NL039)|
+| `natls.style.in_out_groups`                   | `true`, `false` | [`NL041`](../tools/ruletranslator/src/main/resources/rules/NL041)|
 
 # Example
 

--- a/libs/natlint/src/main/java/org/amshove/natlint/analyzers/DefineDataParameterAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/analyzers/DefineDataParameterAnalyzer.java
@@ -8,7 +8,21 @@ import org.amshove.natparse.DiagnosticSeverity;
 import org.amshove.natparse.NodeUtil;
 import org.amshove.natparse.ReadOnlyList;
 import org.amshove.natparse.natural.ISyntaxNode;
+import org.amshove.natparse.natural.ITokenNode;
+import org.amshove.natparse.natural.VariableScope;
+import org.amshove.natparse.natural.project.NaturalFileType;
+import org.amshove.natparse.natural.IDefineData;
+import org.amshove.natparse.natural.IHasDefineData;
+import org.amshove.natparse.natural.IModuleWithBody;
+import org.amshove.natparse.natural.INaturalModule;
 import org.amshove.natparse.natural.IScopeNode;
+import org.amshove.natparse.lexing.SyntaxKind;
+import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class DefineDataParameterAnalyzer extends AbstractAnalyzer
 {
@@ -18,29 +32,92 @@ public class DefineDataParameterAnalyzer extends AbstractAnalyzer
 		DiagnosticSeverity.WARNING
 	);
 
-	private boolean isParameterAnalyserOff;
+	public static final DiagnosticDescription PDA_STRUCTURE_DIAGNOSTIC = DiagnosticDescription.create(
+		"NL041",
+		"%s",
+		DiagnosticSeverity.WARNING
+	);
+
+	private enum GroupName
+	{
+		IN("-IN"),
+		INOUT("-INOUT"),
+		OUT("-OUT");
+
+		final String suffix;
+
+		GroupName(String suffix)
+		{
+			this.suffix = suffix;
+		}
+
+		String fullName(String prefix)
+		{
+			return prefix + suffix;
+		}
+	}
+
+	private static <E extends Enum<E>> Map<String, E> buildCaseInsensitiveLookup(E[] values, java.util.function.Function<E, String> nameFunc)
+	{
+		Map<String, E> map = new HashMap<>(values.length * 2);
+		for (E val : values)
+		{
+			map.put(nameFunc.apply(val).toUpperCase(), val);
+		}
+		return map;
+	}
+
+	private boolean isInlineParameterAnalyserOff;
+	private boolean isInOutGroupsAnalyserOff;
+
+	private IScopeNode findParameterScopeIfEndDefine(ISyntaxNode node)
+	{
+		// Is this an END-DEFINE token?
+		if (!(node instanceof ITokenNode tokenNode) || !(tokenNode.token().kind() == SyntaxKind.END_DEFINE))
+		{
+			return null;
+		}
+
+		// Parent *is* DefineData by assumption
+		ISyntaxNode parent = node.parent();
+		if (!(parent instanceof IDefineData dd))
+		{
+			return null;
+		}
+
+		// Fetch the PARAMETER scope from this DEFINE DATA
+		return dd.findFirstScopeNode(VariableScope.PARAMETER);
+	}
+
+	private void reportPdaError(IAnalyzeContext context, ISyntaxNode node, String message)
+	{
+		context.report(PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(node.position(), message));
+	}
 
 	@Override
 	public ReadOnlyList<DiagnosticDescription> getDiagnosticDescriptions()
 	{
-		return ReadOnlyList.of(USE_OF_INLINE_PARAMETER_IS_DISCOURAGED);
+		return ReadOnlyList.of(USE_OF_INLINE_PARAMETER_IS_DISCOURAGED, PDA_STRUCTURE_DIAGNOSTIC);
 	}
 
 	@Override
 	public void initialize(ILinterContext context)
 	{
-		context.registerNodeAnalyzer(IScopeNode.class, this::analyzeDefineDataParameter);
+		context.registerNodeAnalyzer(IScopeNode.class, this::analyzeInlineParameter);
+		//context.registerNodeAnalyzer(ISyntaxNode.class, this::analyzeParameterStructure);
+		context.registerModuleAnalyzer(this::analyzeModule);
 	}
 
 	@Override
 	public void beforeAnalyzing(IAnalyzeContext context)
 	{
-		isParameterAnalyserOff = !context.getConfiguration(context.getModule().file(), "natls.style.discourage_inlineparameters", OPTION_FALSE).equalsIgnoreCase(OPTION_TRUE);
+		isInlineParameterAnalyserOff = !context.getConfiguration(context.getModule().file(), "natls.style.discourage_inlineparameters", OPTION_FALSE).equalsIgnoreCase(OPTION_TRUE);
+		isInOutGroupsAnalyserOff = !context.getConfiguration(context.getModule().file(), "natls.style.in_out_groups", OPTION_FALSE).equalsIgnoreCase(OPTION_TRUE);
 	}
 
-	private void analyzeDefineDataParameter(ISyntaxNode node, IAnalyzeContext context)
+	private void analyzeInlineParameter(ISyntaxNode node, IAnalyzeContext context)
 	{
-		if (isParameterAnalyserOff)
+		if (isInlineParameterAnalyserOff)
 		{
 			return;
 		}
@@ -59,6 +136,164 @@ public class DefineDataParameterAnalyzer extends AbstractAnalyzer
 		if (scope.scope().isParameter())
 		{
 			context.report(USE_OF_INLINE_PARAMETER_IS_DISCOURAGED.createDiagnostic(node));
+		}
+	}
+
+	private void analyzeModule(INaturalModule module, IAnalyzeContext context)
+	{
+		if (isInOutGroupsAnalyserOff)
+		{
+			return;
+		}
+
+		if (!module.file().getFiletype().canHaveDefineData())
+		{
+			return;
+		}
+
+		if (module instanceof IHasDefineData hasDD)
+		{
+			analyzeParameterStructure(hasDD.defineData(), context);
+		}
+		return;
+	}
+
+	private void analyzeParameterStructure(ISyntaxNode node, IAnalyzeContext context)
+	{
+		if (isInOutGroupsAnalyserOff)
+		{
+			return;
+		}
+
+		if (context.getModule().file().getFiletype() != NaturalFileType.PDA)
+		{
+			return;
+		}
+
+		if (!NodeUtil.moduleContainsNode(context.getModule(), node))
+		{
+			return;
+		}
+
+		var scope = findParameterScopeIfEndDefine(node);
+		if (scope == null)
+		{
+			System.out.println("Skipping PDA structure analysis for node: " + node);
+			return; // Not an END-DEFINE or no parameter scope found
+		}
+
+		for (var variable : scope.variables())
+		{
+			System.out.printf(
+				"L1: name='%s' level=%d isGroup=%s isArray=%s%n",
+				variable.name(), variable.level(), variable.isGroup(), variable.isArray()
+			);
+		}
+
+		var pdaname = context.getModule().file().getOriginalName().trim().toUpperCase();
+		// Case-insensitive lookup: full name -> Group
+		Map<String, GroupName> lookup = buildCaseInsensitiveLookup(GroupName.values(), g -> g.fullName(pdaname));
+		// Tracks if a given GroupName has already been found
+		boolean[] found = new boolean[GroupName.values().length];
+		// Keeps the order of found groups for later order validation
+		List<GroupName> seenOrder = new ArrayList<>();
+		var lvl1Cnt = 0;
+
+		for (var variable : scope.variables())
+		{
+			// Count level 1 elements
+			if (variable.level() == 1)
+			{
+				lvl1Cnt++;
+				continue;
+			}
+
+			// Only check level 2 (parser validates other levels)
+			if (variable.level() != 2)
+			{
+				continue;
+			}
+
+			// Must be a group, and not an array group
+			if (!variable.isGroup() || variable.isArray())
+			{
+				reportPdaError(context, node, "Level 2 must be a group, and not an array group: " + variable.name());
+				return;
+			}
+
+			// Lookup allowed group. Trim and uppercase the variable name to match the lookup keys
+			GroupName groupName = lookup.get(variable.name().trim().toUpperCase());
+			if (groupName == null)
+			{
+				String allowed = Arrays.stream(GroupName.values())
+					.map(x -> x.fullName(pdaname))
+					.collect(Collectors.joining(", "));
+				reportPdaError(context, node, "Invalid level 2 group: " + variable.name() + ". Allowed are: " + allowed + ".");
+				return;
+			}
+
+			// Check for duplicates
+			int idx = groupName.ordinal();
+			if (found[idx])
+			{
+				reportPdaError(context, node, "Duplicate level 2 group: " + variable.name());
+				return;
+			}
+			found[idx] = true;
+
+			// Record the order for later order check
+			seenOrder.add(groupName);
+		} // end-for (each variable)
+
+		// Exactly one level-1 element
+		if (lvl1Cnt != 1)
+		{
+			reportPdaError(context, node, "There must be exactly one level 1 element. Found: " + lvl1Cnt);
+			return;
+		}
+
+		// Order check among present groups only
+		for (int i = 1; i < seenOrder.size(); i++)
+		{
+			if (seenOrder.get(i).ordinal() < seenOrder.get(i - 1).ordinal())
+			{
+				reportPdaError(
+					context, node,
+					"Incorrect order at: " + seenOrder.get(i).fullName(pdaname)
+						+ ". Correct order is: " + GroupName.IN.fullName(pdaname)
+						+ " > " + GroupName.INOUT.fullName(pdaname) + " (optional) > "
+						+ GroupName.OUT.fullName(pdaname) + "."
+				);
+				return;
+			}
+		}
+
+		// Rule:
+		// If INOUT is present → IN and OUT are optional
+		// If INOUT is absent → IN/OUT must be present
+		boolean hasIN = found[GroupName.IN.ordinal()];
+		boolean hasINOUT = found[GroupName.INOUT.ordinal()];
+		boolean hasOUT = found[GroupName.OUT.ordinal()];
+
+		/* If INOUT is absent, IN is mandatory */
+		if (!hasINOUT && !hasIN)
+		{
+			reportPdaError(
+				context, node,
+				"Missing group: " + GroupName.IN.fullName(pdaname)
+			);
+			return;
+		}
+
+		/* IN and OUT must either both be present or both be absent (xor) */
+		if (hasIN ^ hasOUT)
+		{
+			reportPdaError(
+				context, node,
+				GroupName.IN.fullName(pdaname) + " and " + GroupName.OUT.fullName(pdaname)
+					+ " must either both be present or both be absent"
+			);
+			return;
 		}
 	}
 }

--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/DefineDataParameterAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/DefineDataParameterAnalyzerShould.java
@@ -4,12 +4,75 @@ import org.amshove.natlint.linter.AbstractAnalyzerTest;
 import org.amshove.natparse.natural.project.NaturalProject;
 import org.amshove.testhelpers.ProjectName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 class DefineDataParameterAnalyzerShould extends AbstractAnalyzerTest
 {
 	protected DefineDataParameterAnalyzerShould()
 	{
 		super(new DefineDataParameterAnalyzer());
+	}
+
+	@Disabled("This test is not relevant anymore, as we do not support IN/OUT groups in PDAs")
+	void reportLevel1NameMismatch()
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+			DEFINE DATA PARAMETER
+			1 #PDA
+			2 #IN-NAME (A10)
+			END-DEFINE
+			END
+			""",
+			expectDiagnostic(0, DefineDataParameterAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Missing group: PDANAME-IN")
+		);
+	}
+
+	@Disabled("This test is not relevant anymore, as we do not support IN/OUT groups in PDAs")
+	void reportMoreThan1Level1()
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+			DEFINE DATA PARAMETER
+			1 PDANAME
+			2 PDANAME-IN
+			3 #IN-NAME1 (A20)
+			1 PDANAME-IN2
+			2 #IN-NAME2 (A20)
+			END-DEFINE
+			""",
+			expectDiagnostic(0, DefineDataParameterAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "There must be exactly one level 1 element. Found: 2")
+		);
+	}
+
+	@Test
+	void reportLevel2MustBeGroup()
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+			DEFINE DATA PARAMETER
+			1 PDANAME
+			2 PDANAME-IN (20)
+			3 #IN-NAME (A20)
+			END-DEFINE
+			""",
+			expectDiagnostic(0, DefineDataParameterAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 2 must be a group, and not an array group: PDANAME-IN")
+		);
 	}
 
 	@Test

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IVariableNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IVariableNode.java
@@ -27,6 +27,11 @@ public non-sealed interface IVariableNode extends IReferencableNode, IParameterD
 		return dimensions != null && !dimensions.isEmpty();
 	}
 
+	default boolean isGroup()
+	{
+		return this instanceof IGroupNode;
+	}
+
 	/**
 	 * Returns a list of all parent groups in descending (by level) order.
 	 **/

--- a/tools/ruletranslator/src/main/resources/rules/NL041
+++ b/tools/ruletranslator/src/main/resources/rules/NL041
@@ -1,0 +1,18 @@
+name: Parameter Data Area data structure violations
+priority: MAJOR
+tags: bad-practice, pitfall
+type: CODE_SMELL
+description:
+Imaging a PDA named PDANAME, the data structure is expected to be as follows:
+1 PDANAME (only 1 level 1)
+  2 PDANAME-IN (groups for input, output and optionally input/output)
+    3 ....
+  2 PDANAME-OUT
+    3 ....
+Optionally PDANAME-INOUT can be a group too - it can even be standalone, if all your parameters are input/output (rare).
+A PDA structure should follow these rules in order to be able to access each area individually through RESET and MOVE BY NAME statements, and to mention the fewest parameters in CALLNAT's/PERFORM's, which improves readability.
+CALLNAT 'SUBPGM' USING PDANAME
+PERFORM EXTERNAL-SUBROUTINE-NAME PDANAME
+If you have array groups, these are only possible at level > 2.
+
+This behavior can be configured using the ``natls.style.in_out_groups`` option in the [analyzer configuration](/docs/analyzer-config.md)


### PR DESCRIPTION
Introduces a new analyzer rule (NL041) to enforce proper structure of Parameter Data Areas (PDAs) with IN, OUT, and INOUT groups. Updates documentation, adds configuration option, implements structure validation logic in DefineDataParameterAnalyzer, and provides related tests. Also adds a new rule description file for NL041.