### PR TITLE
Add PDA structure analyzer and rule NL041

### DIFF
--- a/docs/analyzer-config.md
+++ b/docs/analyzer-config.md
@@ -16,6 +16,7 @@ The following configurations can be set in a `.editorconfig` file to configure p
 | `natls.style.discourage_hidden_dbms`          | `true`, `false` | [`NL035`](../tools/ruletranslator/src/main/resources/rules/NL035)|
 | `natls.style.discourage_long_literals`        | `true`, `false` | [`NL038`](../tools/ruletranslator/src/main/resources/rules/NL038)|
 | `natls.style.discourage_lowercase_code`       | `true`, `false` | [`NL039`](../tools/ruletranslator/src/main/resources/rules/NL039)|
+| `natls.style.in_out_groups`                   | `true`, `false` | [`NL041`](../tools/ruletranslator/src/main/resources/rules/NL041)|
 
 # Example
 

--- a/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
@@ -1,0 +1,125 @@
+package org.amshove.natlint.analyzers;
+
+import org.amshove.natlint.api.AbstractAnalyzer;
+import org.amshove.natlint.api.DiagnosticDescription;
+import org.amshove.natlint.api.IAnalyzeContext;
+import org.amshove.natlint.api.ILinterContext;
+import org.amshove.natparse.DiagnosticSeverity;
+import org.amshove.natparse.ReadOnlyList;
+import org.amshove.natparse.natural.IHasDefineData;
+import org.amshove.natparse.natural.INaturalModule;
+import org.amshove.natparse.natural.project.NaturalFileType;
+
+import java.util.List;
+
+public class PdaStructureAnalyzer extends AbstractAnalyzer
+{
+	public static final DiagnosticDescription PDA_STRUCTURE_DIAGNOSTIC = DiagnosticDescription.create(
+		"NL041",
+		"%s",
+		DiagnosticSeverity.WARNING
+	);
+
+	private static final List<String> ALLOWED_GROUP_SUFFIXES = List.of("-OUT", "-IN", "-INOUT");
+	private boolean isInOutGroupsAnalyserOff;
+
+	@Override
+	public ReadOnlyList<DiagnosticDescription> getDiagnosticDescriptions()
+	{
+		return ReadOnlyList.of(PDA_STRUCTURE_DIAGNOSTIC);
+	}
+
+	@Override
+	public void initialize(ILinterContext context)
+	{
+		context.registerModuleAnalyzer(this::analyzePda);
+	}
+
+	@Override
+	public void beforeAnalyzing(IAnalyzeContext context)
+	{
+		isInOutGroupsAnalyserOff = !context.getConfiguration(context.getModule().file(), "natls.style.in_out_groups", OPTION_FALSE).equalsIgnoreCase(OPTION_TRUE);
+	}
+
+	private void analyzePda(INaturalModule module, IAnalyzeContext context)
+	{
+		if (isInOutGroupsAnalyserOff)
+		{
+			return;
+		}
+
+		if (module.file().getFiletype() != NaturalFileType.PDA)
+		{
+			return;
+		}
+
+		if (!(module instanceof IHasDefineData defineData) || defineData.defineData() == null)
+		{
+			return;
+		}
+
+		var pdaName = context.getModule().file().getOriginalName();
+		var levelOneVariables = defineData.defineData().variables().stream().filter(v -> v.level() == 1).count();
+
+		if (levelOneVariables > 1)
+		{
+			context.report(
+				PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+					defineData.defineData()
+						.diagnosticPosition(),
+					"PDAs should only have one Level 1 group"
+				)
+			);
+			return;
+		}
+
+		for (var variable : defineData.defineData().variables())
+		{
+			if (variable.level() == 1 && !variable.name().equalsIgnoreCase(pdaName))
+			{
+				System.out.println("Level 1 variable name mismatch: " + variable.name() + " vs " + pdaName);
+				context.report(
+					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+						variable.diagnosticPosition(), "Level 1 group name should match the PDA name"
+					)
+				);
+			}
+
+			if (variable.level() == 2)
+			{
+				if (!variable.isGroup() || variable.isArray())
+				{
+					context.report(
+						PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+							variable.diagnosticPosition(),
+							"Level 2 must be a group, and not an array group"
+						)
+					);
+				}
+				else
+				{
+					if (!variable.name().toUpperCase().startsWith(pdaName.toUpperCase()))
+					{
+						context.report(
+							PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+								variable.diagnosticPosition(),
+								"Level 2 group name should start with PDA name: " + pdaName
+							)
+						);
+					}
+				}
+			}
+
+			var hasSuffix = ALLOWED_GROUP_SUFFIXES.stream().anyMatch(suffix -> variable.name().endsWith(suffix));
+			if (variable.level() == 2 && variable.isGroup() && !hasSuffix)
+			{
+				context.report(
+					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+						variable.diagnosticPosition(), "Level 2 groups should have one of these suffixes: " + String.join(", ", ALLOWED_GROUP_SUFFIXES)
+					)
+				);
+				continue;
+			}
+		}
+	}
+}

--- a/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
@@ -83,12 +83,13 @@ public class PdaStructureAnalyzer extends AbstractAnalyzer
 				);
 			}
 
-			if (variable.level() == 2 && (!variable.isGroup() || variable.isArray()))
+			System.out.println("Analyzing variable: " + variable.name() + " at level " + variable.level() + "isGroup: " + variable.isGroup() + " isArray: " + variable.isArray());
+			if (variable.level() < 3 && (!variable.isGroup() || variable.isArray()))
 			{
 				context.report(
 					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
 						variable.diagnosticPosition(),
-						"Level 2 must be a group, and not an array group"
+						"Level %d must be a group, and not an array group".formatted(variable.level())
 					)
 				);
 			}

--- a/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
@@ -59,9 +59,8 @@ public class PdaStructureAnalyzer extends AbstractAnalyzer
 		}
 
 		var pdaName = context.getModule().file().getOriginalName();
-		var levelOneVariables = defineData.defineData().variables().stream().filter(v -> v.level() == 1).count();
 
-		if (levelOneVariables > 1)
+		if (defineData.defineData().variables().stream().filter(v -> v.level() == 1).count() > 1)
 		{
 			context.report(
 				PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
@@ -77,7 +76,6 @@ public class PdaStructureAnalyzer extends AbstractAnalyzer
 		{
 			if (variable.level() == 1 && !variable.name().equalsIgnoreCase(pdaName))
 			{
-				System.out.println("Level 1 variable name mismatch: " + variable.name() + " vs " + pdaName);
 				context.report(
 					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
 						variable.diagnosticPosition(), "Level 1 group name should match the PDA name"
@@ -85,40 +83,34 @@ public class PdaStructureAnalyzer extends AbstractAnalyzer
 				);
 			}
 
-			if (variable.level() == 2)
+			if (variable.level() == 2 && (!variable.isGroup() || variable.isArray()))
 			{
-				if (!variable.isGroup() || variable.isArray())
-				{
-					context.report(
-						PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
-							variable.diagnosticPosition(),
-							"Level 2 must be a group, and not an array group"
-						)
-					);
-				}
-				else
-				{
-					if (!variable.name().toUpperCase().startsWith(pdaName.toUpperCase()))
-					{
-						context.report(
-							PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
-								variable.diagnosticPosition(),
-								"Level 2 group name should start with PDA name: " + pdaName
-							)
-						);
-					}
-				}
+				context.report(
+					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+						variable.diagnosticPosition(),
+						"Level 2 must be a group, and not an array group"
+					)
+				);
+			}
+
+			if (variable.level() == 2 && !variable.name().toUpperCase().startsWith(pdaName.toUpperCase()))
+			{
+				context.report(
+					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
+						variable.diagnosticPosition(),
+						"Level 2 group name should start with PDA name: " + pdaName
+					)
+				);
 			}
 
 			var hasSuffix = ALLOWED_GROUP_SUFFIXES.stream().anyMatch(suffix -> variable.name().endsWith(suffix));
-			if (variable.level() == 2 && variable.isGroup() && !hasSuffix)
+			if (variable.level() == 2 && !hasSuffix)
 			{
 				context.report(
 					PDA_STRUCTURE_DIAGNOSTIC.createFormattedDiagnostic(
 						variable.diagnosticPosition(), "Level 2 groups should have one of these suffixes: " + String.join(", ", ALLOWED_GROUP_SUFFIXES)
 					)
 				);
-				continue;
 			}
 		}
 	}

--- a/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/analyzers/PdaStructureAnalyzer.java
@@ -83,7 +83,6 @@ public class PdaStructureAnalyzer extends AbstractAnalyzer
 				);
 			}
 
-			System.out.println("Analyzing variable: " + variable.name() + " at level " + variable.level() + "isGroup: " + variable.isGroup() + " isArray: " + variable.isArray());
 			if (variable.level() < 3 && (!variable.isGroup() || variable.isArray()))
 			{
 				context.report(

--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/PdaStructureAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/PdaStructureAnalyzerShould.java
@@ -1,0 +1,147 @@
+package org.amshove.natlint.analyzers;
+
+import org.amshove.natlint.linter.AbstractAnalyzerTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PdaStructureAnalyzerShould extends AbstractAnalyzerTest
+{
+	protected PdaStructureAnalyzerShould()
+	{
+		super(new PdaStructureAnalyzer());
+	}
+
+	@Test
+	void raiseADiagnosticIfMoreThan1Level1()
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+			DEFINE DATA PARAMETER
+			1 PDANAME
+			2 PDANAME-IN
+			3 #IN-NAME1 (A20)
+			1 PDANAME2
+			2 PDANAME-OUT
+			3 #IN-NAME2 (A20)
+			END-DEFINE
+			""",
+			expectDiagnostic(0, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "PDAs should only have one Level 1 group")
+		);
+	}
+
+	@Test
+	void raiseADiagnosticIfLevel1NameMismatch()
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+			DEFINE DATA PARAMETER
+			1 #PDA
+			2 PDANAME-IN
+			3 #VAR1 (A20)
+			END-DEFINE
+			""",
+			expectDiagnostic(1, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 1 group name should match the PDA name")
+		);
+	}
+
+	@Disabled
+	void raiseADiagnosticIfLevel2NameMismatch()
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+			DEFINE DATA PARAMETER
+			1 PDANAME
+			2 PDA-IN
+			3 #VAR1 (A20)
+			END-DEFINE
+			""",
+			expectDiagnostic(2, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 2 group name should have one of these suffixes: -OUT, -IN, -INOUT")
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings =
+	{
+		"(1:10)", "(20)", "(A10)", "(L)", "(P3/1:10, 2:20)"
+	})
+	void raiseADiagnosticIfNotAGroupButNotAnArrayGroup(String suffix)
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+   			DEFINE DATA PARAMETER
+   			1 PDANAME
+     		2 PDANAME-IN %s
+        	3 #VAR (A1)
+   			END-DEFINE
+			""".formatted(suffix), expectDiagnostic(2, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 2 must be a group, and not an array group")
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings =
+	{
+		"_IN", "_OUT", "_INOUT", "HELLO", "1", "#"
+	})
+	void raiseADiagnosticIfAGroupHasAnDisallowedSuffix(String suffix)
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+   			DEFINE DATA PARAMETER
+   			1 PDANAME
+     		2 PDANAME%s
+        	3 #VAR (A1)
+   			END-DEFINE
+   			""".formatted(suffix), expectDiagnostic(2, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 2 groups should have one of these suffixes: -OUT, -IN, -INOUT")
+		);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings =
+	{
+		"-IN", "-OUT", "-INOUT"
+	})
+	void raiseNoDiagnosticIfAGroupHasAnAllowedSuffix(String suffix)
+	{
+		configureEditorConfig("""
+			[*]
+			natls.style.in_out_groups=true
+			""");
+
+		testDiagnostics(
+			"PDANAME.NSA", """
+   			DEFINE DATA PARAMETER
+   			1 PDANAME
+     		2 PDANAME%s
+        	3 #VAR (A1)
+   			END-DEFINE
+   			""".formatted(suffix), expectNoDiagnosticOfType(PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC)
+		);
+	}
+}

--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/PdaStructureAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/PdaStructureAnalyzerShould.java
@@ -1,7 +1,6 @@
 package org.amshove.natlint.analyzers;
 
 import org.amshove.natlint.linter.AbstractAnalyzerTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -56,7 +55,7 @@ class PdaStructureAnalyzerShould extends AbstractAnalyzerTest
 		);
 	}
 
-	@Disabled
+	@Test
 	void raiseADiagnosticIfLevel2NameMismatch()
 	{
 		configureEditorConfig("""
@@ -72,7 +71,7 @@ class PdaStructureAnalyzerShould extends AbstractAnalyzerTest
 			3 #VAR1 (A20)
 			END-DEFINE
 			""",
-			expectDiagnostic(2, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 2 group name should have one of these suffixes: -OUT, -IN, -INOUT")
+			expectDiagnostic(2, PdaStructureAnalyzer.PDA_STRUCTURE_DIAGNOSTIC, "Level 2 group name should start with PDA name: PDANAME")
 		);
 	}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IVariableNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IVariableNode.java
@@ -21,6 +21,11 @@ public non-sealed interface IVariableNode extends IReferencableNode, IParameterD
 
 	boolean isInView();
 
+	default boolean isGroup()
+	{
+		return this instanceof IGroupNode;
+	}
+
 	default boolean isArray()
 	{
 		var dimensions = dimensions();

--- a/tools/ruletranslator/src/main/resources/rules/NL041
+++ b/tools/ruletranslator/src/main/resources/rules/NL041
@@ -1,0 +1,18 @@
+name: Parameter Data Area data structure violations
+priority: MAJOR
+tags: bad-practice, pitfall
+type: CODE_SMELL
+description:
+Imaging a PDA named PDANAME, the data structure is expected to be as follows:
+1 PDANAME (only 1 level 1)
+  2 PDANAME-IN (groups for input, output and optionally input/output)
+    3 ....
+  2 PDANAME-OUT
+    3 ....
+Optionally PDANAME-INOUT can be a group too - it can even be standalone, if all your parameters are input/output (rare).
+A PDA structure should follow these rules in order to be able to access each area individually through RESET and MOVE BY NAME statements, and to mention the fewest parameters in CALLNAT's/PERFORM's, which improves readability.
+CALLNAT 'SUBPGM' USING PDANAME
+PERFORM EXTERNAL-SUBROUTINE-NAME PDANAME
+If you have array groups, these are only possible at level > 2.
+
+This behavior can be configured using the ``natls.style.in_out_groups`` option in the [analyzer configuration](/docs/analyzer-config.md)


### PR DESCRIPTION
Introduces PdaStructureAnalyzer to enforce structure rules for Parameter Data Areas (PDAs) based on the new NL041 rule. Updates documentation and adds tests for the analyzer. Also adds the isGroup() method to IVariableNode to support group detection.