### PR TITLE
Allow LOGIC type as COMPRESS operand

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/TypeChecker.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/TypeChecker.java
@@ -96,7 +96,7 @@ final class TypeChecker implements ISyntaxNodeVisitor
 		for (var operand : compress.operands())
 		{
 			var operandType = inferDataType(operand);
-			if (operandType.format() == DataFormat.LOGIC || operandType.format() == DataFormat.CONTROL)
+			if (operandType.format() == DataFormat.CONTROL)
 			{
 				report(ParserErrors.typeMismatch("COMPRESS operand can't be of type %s".formatted(operandType.format().identifier()), operand), operand);
 			}

--- a/libs/natparse/src/test/resources/org/amshove/natparse/parsing/typing/compressTests
+++ b/libs/natparse/src/test/resources/org/amshove/natparse/parsing/typing/compressTests
@@ -15,7 +15,7 @@ COMPRESS #NUM #UNI INTO #UNI
 COMPRESS #ALPHA INTO #NUM /* !{D:ERROR:NPP037} target needs to be A, U or B
 
 COMPRESS #CTRL INTO #ALPHA /* !{D:ERROR:NPP037} (C) can't be used as operand
-COMPRESS #LOGIC INTO #ALPHA /* !{D:ERROR:NPP037} (L) can't be used as operand
+COMPRESS #LOGIC INTO #ALPHA /* {D:ERROR:NPP037} (L) can be used as operand
 
 
 END

--- a/libs/natparse/src/test/resources/org/amshove/natparse/parsing/typing/compressTests
+++ b/libs/natparse/src/test/resources/org/amshove/natparse/parsing/typing/compressTests
@@ -15,7 +15,5 @@ COMPRESS #NUM #UNI INTO #UNI
 COMPRESS #ALPHA INTO #NUM /* !{D:ERROR:NPP037} target needs to be A, U or B
 
 COMPRESS #CTRL INTO #ALPHA /* !{D:ERROR:NPP037} (C) can't be used as operand
-COMPRESS #LOGIC INTO #ALPHA /* {D:ERROR:NPP037} (L) can be used as operand
-
 
 END


### PR DESCRIPTION
Removed LOGIC type from the list of disallowed operand types for the COMPRESS statement in TypeChecker. Updated related test to reflect that LOGIC operands are now permitted.