### PR TITLE
Don't consider REDEFINEs as empty groups when they contain filler

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataParser.java
@@ -112,7 +112,9 @@ public class DefineDataParser extends AbstractParser<IDefineData>
 		{
 			return;
 		}
-		if (groupNode.variables().isEmpty())
+
+		var hasFillerBytes = groupNode instanceof IRedefinitionNode redefine && redefine.fillerBytes() > 0;
+		if (groupNode.variables().isEmpty() && !hasFillerBytes)
 		{
 			report(ParserErrors.emptyGroupVariable(groupNode));
 		}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/ViewParser.java
@@ -4,6 +4,7 @@ import org.amshove.natparse.lexing.SyntaxKind;
 import org.amshove.natparse.lexing.SyntaxToken;
 import org.amshove.natparse.natural.DataFormat;
 import org.amshove.natparse.natural.IArrayDimension;
+import org.amshove.natparse.natural.IRedefinitionNode;
 import org.amshove.natparse.natural.ITokenNode;
 import org.amshove.natparse.natural.ddm.FieldType;
 import org.amshove.natparse.natural.ddm.IGroupField;
@@ -241,7 +242,8 @@ class ViewParser extends AbstractParser<ViewNode>
 			group.addVariable(nestedVariable);
 		}
 
-		if (group.variables().isEmpty())
+		var hasFillerBytes = group instanceof IRedefinitionNode redefine && redefine.fillerBytes() > 0;
+		if (group.variables().isEmpty() && !hasFillerBytes)
 		{
 			report(ParserErrors.emptyGroupVariable(group));
 		}

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -2541,6 +2541,29 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 		);
 	}
 
+	@Test
+	void raiseADiagnosticForEmptyGroups()
+	{
+		assertDiagnostic("""
+			DEFINE DATA LOCAL
+			1 #GRP
+			END-DEFINE
+			""", ParserError.GROUP_CANNOT_BE_EMPTY);
+	}
+
+	@Test
+	void notConsiderARedefineAsEmptyGroupWhenItContainsOnlyFiller()
+	{
+		// https://github.com/markusamshove/natls/issues/384
+		assertParsesWithoutDiagnostics("""
+			DEFINE DATA LOCAL
+			1 AAA (A10)
+			1 REDEFINE AAA
+			2 FILLER 10X
+			END-DEFINE
+			""");
+	}
+
 	@TestFactory
 	Stream<DynamicTest> notRaiseADiagnosticForScopesInNonDataAreas()
 	{


### PR DESCRIPTION
closes #384