### PR TITLE
Update rule docs for NL029, NL035, NL041 with examples

### DIFF
--- a/docs/website/analyzer-config.md
+++ b/docs/website/analyzer-config.md
@@ -30,19 +30,19 @@ The following configurations can be set in an `.editorconfig` file to configure 
 
 | Property                                      | Possible values | Description |
 |-----------------------------------------------| --- | --- |
-| `natls.style.comparisons`                     | `sign`, `short`, `false` | [`NL006`](../tools/ruletranslator/src/main/resources/rules/NL006)|
-| `natls.style.disallowtoplevelvars`            | `true`, `false` | [`NL018`](../tools/ruletranslator/src/main/resources/rules/NL018)|
-| `natls.style.qualifyvars`                     | `true`, `false` | [`NL019`](../tools/ruletranslator/src/main/resources/rules/NL019)|
-| `natls.style.discourage_independent`          | `true`, `false` | [`NL028`](../tools/ruletranslator/src/main/resources/rules/NL028)|
-| `natls.style.discourage_gitmarkers`           | `true`, `false` | [`NL030`](../tools/ruletranslator/src/main/resources/rules/NL030)|
-| `natls.style.discourage_inlineparameters`     | `true`, `false` | [`NL031`](../tools/ruletranslator/src/main/resources/rules/NL031)|
-| `natls.style.discourage_hiddentransactions`   | `true`, `false` | [`NL032`](../tools/ruletranslator/src/main/resources/rules/NL032)|
-| `natls.style.discourage_hiddenworkfiles`      | `true`, `false` | [`NL033`](../tools/ruletranslator/src/main/resources/rules/NL033)|
-| `natls.style.mark_mainframelongline`          | `true`, `false` | [`NL034`](../tools/ruletranslator/src/main/resources/rules/NL034)|
-| `natls.style.discourage_hidden_dbms`          | `true`, `false` | [`NL035`](../tools/ruletranslator/src/main/resources/rules/NL035)|
-| `natls.style.discourage_long_literals`        | `true`, `false` | [`NL038`](../tools/ruletranslator/src/main/resources/rules/NL038)|
-| `natls.style.discourage_lowercase_code`       | `true`, `false` | [`NL039`](../tools/ruletranslator/src/main/resources/rules/NL039)|
-| `natls.style.in_out_groups`                   | `true`, `false` | [`NL041`](../tools/ruletranslator/src/main/resources/rules/NL041)|
+| `natls.style.comparisons`                     | `sign`, `short`, `false` | [`NL006`](https://nat-ls.github.io/diagnostics/nl006)|
+| `natls.style.disallowtoplevelvars`            | `true`, `false` | [`NL018`](https://nat-ls.github.io/diagnostics/nl018)|
+| `natls.style.qualifyvars`                     | `true`, `false` | [`NL019`](https://nat-ls.github.io/diagnostics/nl019)|
+| `natls.style.discourage_independent`          | `true`, `false` | [`NL028`](https://nat-ls.github.io/diagnostics/nl028)|
+| `natls.style.discourage_gitmarkers`           | `true`, `false` | [`NL030`](https://nat-ls.github.io/diagnostics/nl030)|
+| `natls.style.discourage_inlineparameters`     | `true`, `false` | [`NL031`](https://nat-ls.github.io/diagnostics/nl031)|
+| `natls.style.discourage_hiddentransactions`   | `true`, `false` | [`NL032`](https://nat-ls.github.io/diagnostics/nl032)|
+| `natls.style.discourage_hiddenworkfiles`      | `true`, `false` | [`NL033`](https://nat-ls.github.io/diagnostics/nl033)|
+| `natls.style.mark_mainframelongline`          | `true`, `false` | [`NL034`](https://nat-ls.github.io/diagnostics/nl034)|
+| `natls.style.discourage_hidden_dbms`          | `true`, `false` | [`NL035`](https://nat-ls.github.io/diagnostics/nl035)|
+| `natls.style.discourage_long_literals`        | `true`, `false` | [`NL038`](https://nat-ls.github.io/diagnostics/nl038)|
+| `natls.style.discourage_lowercase_code`       | `true`, `false` | [`NL039`](https://nat-ls.github.io/diagnostics/nl039)|
+| `natls.style.in_out_groups`                   | `true`, `false` | [`NL041`](https://nat-ls.github.io/diagnostics/nl041/)|
 
 # Example
 

--- a/tools/ruletranslator/src/main/resources/rules/NL029
+++ b/tools/ruletranslator/src/main/resources/rules/NL029
@@ -4,3 +4,61 @@ tags: clumsy, brain-overload, confusing, bad-practice
 type: CODE_SMELL
 description:
 The Natural language accepts code in between definitions of subroutines. This is strongly discouraged, as it is confusing, hides functionality and greatly lessens readability and ease of maintenance.
+
+## Non compliant
+
+```natural
+DEFINE DATA LOCAL
+1 #A (N3)
+1 #B (N3)
+END-DEFINE
+
+#A := 5
+#B := 7
+
+DEFINE SUBROUTINE CALC-ADD
+  ADD #A #B
+  WRITE 'Sum:' #A
+END-SUBROUTINE
+
+/* Executable code in between subroutines
+PERFORM CALC-ADD
+PERFORM CALC-MULT
+
+DEFINE SUBROUTINE CALC-MULT
+  MULTIPLY #A BY #B
+  WRITE 'Product:' #A
+END-SUBROUTINE
+
+END
+```
+
+## Compliant
+
+```natural
+DEFINE DATA LOCAL
+1 #A (N3)
+1 #B (N3)
+END-DEFINE
+
+#A := 5
+#B := 7
+PERFORM CALC-ADD
+PERFORM CALC-MULT
+
+DEFINE SUBROUTINE CALC-ADD
+  ADD #A #B
+  WRITE 'Sum:' #A
+END-SUBROUTINE
+
+/* No executable code between subroutines.
+
+DEFINE SUBROUTINE CALC-MULT
+  MULTIPLY #A BY #B
+  WRITE 'Product:' #A
+END-SUBROUTINE
+
+#A := 6 /* Allowed
+
+END
+```

--- a/tools/ruletranslator/src/main/resources/rules/NL035
+++ b/tools/ruletranslator/src/main/resources/rules/NL035
@@ -4,3 +4,68 @@ tags: clumsy, confusing, bad-practice
 type: CODE_SMELL
 description:
 Hides implementation for XREF, because data access is shown in all INCLUDErs of the Copycode, and not just the Copycode itself. Interface is copied amongst INCLUDErs instead of being isolated. Meaning changes in interface will affect all INCLUDErs. Access modules should be isolated in Subprograms instead.
+
+## Non compliant
+
+```natural
+* COPYCODE: CUSTFIND
+FIND CUSTOMER WITH NAME = #SEARCH-NAME
+  MOVE CUSTOMER-ID   TO #CUST-ID
+  MOVE CUSTOMER-ADDR TO #CUST-ADDR
+END-FIND
+```
+
+Example program using the copycode
+```natural
+DEFINE DATA
+LOCAL
+1 #SEARCH-NAME (A30)
+1 #CUST-ID     (N10)
+1 #CUST-ADDR   (A50)
+END-DEFINE
+INPUT 'Enter customer name:' #SEARCH-NAME
+INCLUDE CUSTFIND
+DISPLAY #CUST-ID #CUST-ADDR
+END
+```
+
+## Compliant
+
+Use an interface (Parameter Data Area)
+
+```natural
+DEFINE DATA
+PARAMETER
+1 PDACUST
+  2 PDACUST-IN
+    3 P-SEARCH-NAME (A30)
+  2 PDACUST-OUT
+    3 P-CUST-ID     (N10)
+    3 P-CUST-ADDR   (A50)
+    ...
+END-DEFINE
+```
+
+Subprogram (FINDCUST)
+```natural
+DEFINE DATA
+PARAMETER USING PDACUST
+END-DEFINE
+
+RESET PDACUST.PDACUST-OUT
+FIND CUSTOMER WITH NAME = P-SEARCH-NAME
+  MOVE CUSTOMER.CUSTOMER-ID   TO PDACUST.P-CUST-ID
+  MOVE CUSTOMER.CUSTOMER-ADDR TO PDACUST.P-CUST-ADDR
+END-FIND
+END
+```
+Example program using the subprogram
+```natural
+DEFINE DATA
+LOCAL USING PDACUST
+END-DEFINE
+INPUT 'Enter customer name:' PDACUST.P-SEARCH-NAME
+CALLNAT 'FINDCUST' USING PDACUST
+DISPLAY PDACUST.PDACUST-OUT
+END
+```

--- a/tools/ruletranslator/src/main/resources/rules/NL041
+++ b/tools/ruletranslator/src/main/resources/rules/NL041
@@ -15,13 +15,19 @@ Imaging a PDA named `PDANAME`, the data structure is expected to be as follows:
 
 Optionally `PDANAME-INOUT` can be a group too - it can even be standalone, if all your parameters are input/output (rare).
 
-A PDA structure should follow these rules in order to be able to access each area individually through `RESET` and `MOVE BY NAME` statements, and to mention the fewest parameters in `CALLNAT`'s/`PERFORM`'s, which improves readability.
+A PDA structure should follow these rules in order to be able to access each area individually through `RESET` and `MOVE BY NAME` statements:
+```natural
+RESET PDANAME.PDANAME-OUT
+MOVE BY NAME other-structure TO PDANAME.PDANAME-IN
+```
+
+and to mention the fewest parameters in `CALLNAT`'s/`PERFORM`'s, while at the same time making a clear reference to the PDA in use, which improves readability:
 
 ```natural
 CALLNAT 'SUBPGM' USING PDANAME
 PERFORM EXTERNAL-SUBROUTINE-NAME PDANAME
 ```
 
-If you have array groups, these are only possible at level > 2.
+If you have array groups, these are only possible at levels > 2.
 
 This behavior can be configured using the `natls.style.in_out_groups` option in the [analyzer configuration](/docs/analyzer-config.md)


### PR DESCRIPTION
Added compliant and non-compliant code examples to NL029 and NL035 rule documentation for clarity. Improved explanation and added code snippets to NL041. Updated analyzer-config.md to use direct links to online diagnostics documentation for each rule.