### PR TITLE
Map Parsing

### DIFF
--- a/docs/maps/maps.md
+++ b/docs/maps/maps.md
@@ -1,0 +1,76 @@
+# Maps
+
+Maps are a bit different to the other source modules.
+
+- Multiple programs
+- Magic comments
+
+## Multiple Programs
+
+Maps may contain rules, or references to Predict Free Rules.
+
+- [ ] `natls` cannot parse these rules at present and treats their `DEFINE DATA` blocks as errors
+- [ ] No idea how to cope with Predict Free Rules
+
+## Rulevar
+
+```
+RULEVAR F09CASE.SURNAME
+RULEVAR D01CASE.TRANSACTION-TYPE
+```
+
+- `RULEVAR` is followed by rule type `F` or `D` and then an index (for that type)
+- `F` seems to be "Form rule"
+    - Followed by a blank `INCDIC`
+    - Then by a rule program inline in the map
+- `D` seems to be "Dictionary rule"
+    - Followed by an `INCDIC` and a name : Predict free rule
+    - Or `INCDIR` and two names : this is injected when a database field is referenced in the map and automatically
+    inlines Predict rules defined on that field
+
+
+## Magic Comments
+
+Less importantly, the comments in Maps contain data, somewhat cryptically encoded in places.
+
+- [ ] Is this just for the map editor in N1 or do they have an effect on how maps run?
+
+### Properties Thing
+
+```
+* MAP2: MAP PROFILES *****************************        200***********
+* .TTAAAMMOO   D I D I N D I D I        ?_)^&:+(                       *
+* 024079        N0NNUCN             X .      01 SYSPROF NR             *
+************************************************************************
+```
+
+#### Line 2
+
+```
+            1         2         3         4         5         6
+  0123456789012345678901234567890123456789012345678901234567890123456789
+* 024079        N0NNUCNJLHK         X .      01 SYSPROF NR   CONTROLV  *
+
+21 : Filler, Optional partial
+22 : Filler, Required partial
+23 : Filler, Optional complete
+24 : Filler, Required complete
+36 : Label Filler
+59 : Control variable (A8)
+
+```
+
+
+## SAG docs
+
+(in error code NAT0721)
+
+INCDIR statements are automatically created if a database field is
+included in a map. When the map is catalogued, these instructions will
+effect an automatic incorporation of processing rules which might
+exist for this field on Predict.
+
+## RULEVAR
+
+- Can inline a program including DEFINE block
+- Has access to the top level object defines plus any local ones

--- a/docs/maps/maps.md
+++ b/docs/maps/maps.md
@@ -35,6 +35,21 @@ Less importantly, the comments in Maps contain data, somewhat cryptically encode
 
 - [ ] Is this just for the map editor in N1 or do they have an effect on how maps run?
 
+### Default Usage Comment
+
+```
+* INPUT USING MAP 'XXXXXXXX'
+*     PARAM-1 PARAM-2 PARAM-3
+*     PARAM-4 PARAM5(*)
+DEFINE DATA PARAMETER
+```
+
+This comment block **is consumed by the compiler**.
+
+If you don't supply parameters in your `INPUT USING MAP` statement,
+this set of parameters will be used. This means that programs that do
+this will fail `PCHECK` if you change the parameter set but don't change this magic comment.
+
 ### Properties Thing
 
 ```

--- a/libs/natlint/src/main/java/org/amshove/natlint/api/IAnalyzeContext.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/api/IAnalyzeContext.java
@@ -1,5 +1,6 @@
 package org.amshove.natlint.api;
 
+import org.amshove.natparse.IDiagnostic;
 import org.amshove.natparse.natural.INaturalModule;
 import org.amshove.natparse.natural.project.NaturalFile;
 import org.amshove.natparse.natural.project.NaturalFileType;
@@ -8,7 +9,7 @@ public interface IAnalyzeContext
 {
 	INaturalModule getModule();
 
-	void report(LinterDiagnostic diagnostic);
+	void report(IDiagnostic diagnostic);
 
 	/**
 	 * Returns the .editorconfig setting for the given property matching the files path otherwise returns given
@@ -41,6 +42,9 @@ public interface IAnalyzeContext
 	 */
 	default boolean isIncludableFileType()
 	{
-		return isFiletype(NaturalFileType.COPYCODE, NaturalFileType.LDA, NaturalFileType.GDA, NaturalFileType.PDA, NaturalFileType.MAP);
+		return isFiletype(
+			NaturalFileType.COPYCODE, NaturalFileType.LDA, NaturalFileType.GDA, NaturalFileType.PDA,
+			NaturalFileType.MAP
+		);
 	}
 }

--- a/libs/natlint/src/main/java/org/amshove/natlint/api/IDiagnosticReporter.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/api/IDiagnosticReporter.java
@@ -1,7 +1,9 @@
 package org.amshove.natlint.api;
 
+import org.amshove.natparse.IDiagnostic;
+
 @FunctionalInterface
 public interface IDiagnosticReporter
 {
-	void report(LinterDiagnostic diagnostic);
+	void report(IDiagnostic diagnostic);
 }

--- a/libs/natlint/src/main/java/org/amshove/natlint/api/LinterDiagnostic.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/api/LinterDiagnostic.java
@@ -12,7 +12,6 @@ public class LinterDiagnostic implements IDiagnostic
 	private final IPosition position;
 	private final DiagnosticSeverity severity;
 	private final String message;
-	private final IPosition originalPosition;
 	private final List<AdditionalDiagnosticInfo> additionalInfos;
 
 	public LinterDiagnostic(String id, IPosition position, DiagnosticSeverity severity, String message)
@@ -22,20 +21,19 @@ public class LinterDiagnostic implements IDiagnostic
 
 	public LinterDiagnostic(String id, IPosition position, IPosition originalPosition, DiagnosticSeverity severity, String message)
 	{
-		this(id, position, originalPosition, severity, message, new ArrayList<>());
+		this(id, position, severity, message, new ArrayList<>());
 		if (originalPosition != null && !originalPosition.isSamePositionAs(position))
 		{
 			additionalInfos.add(new AdditionalDiagnosticInfo("Occurred here", originalPosition));
 		}
 	}
 
-	public LinterDiagnostic(String id, IPosition position, IPosition originalPosition, DiagnosticSeverity severity, String message, List<AdditionalDiagnosticInfo> additionalInfos)
+	private LinterDiagnostic(String id, IPosition position, DiagnosticSeverity severity, String message, List<AdditionalDiagnosticInfo> additionalInfos)
 	{
 		this.id = id;
 		this.position = position;
 		this.severity = severity;
 		this.message = message;
-		this.originalPosition = originalPosition;
 		this.additionalInfos = additionalInfos;
 	}
 
@@ -102,18 +100,6 @@ public class LinterDiagnostic implements IDiagnostic
 			", message='" + message + '\'' +
 			", position=" + position +
 			'}';
-	}
-
-	public LinterDiagnostic withSeverity(DiagnosticSeverity newSeverity)
-	{
-		return new LinterDiagnostic(
-			id,
-			position,
-			originalPosition,
-			newSeverity,
-			message,
-			additionalInfos
-		);
 	}
 
 	public void addAdditionalInfo(AdditionalDiagnosticInfo info)

--- a/libs/natlint/src/main/java/org/amshove/natlint/cli/CliAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/cli/CliAnalyzer.java
@@ -3,7 +3,6 @@ package org.amshove.natlint.cli;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.amshove.natlint.api.LinterDiagnostic;
 import org.amshove.natlint.cli.sinks.FileStatusSink;
 import org.amshove.natlint.cli.sinks.FileStatusSink.MessageType;
 import org.amshove.natlint.cli.sinks.IDiagnosticSink;
@@ -325,7 +324,7 @@ public class CliAnalyzer
 		}
 	}
 
-	private ReadOnlyList<LinterDiagnostic> lint(NaturalFile file, INaturalModule module, ArrayList<IDiagnostic> allDiagnosticsInFile)
+	private ReadOnlyList<IDiagnostic> lint(NaturalFile file, INaturalModule module, ArrayList<IDiagnostic> allDiagnosticsInFile)
 	{
 		try
 		{

--- a/libs/natlint/src/main/java/org/amshove/natlint/linter/AnalyzeContext.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/linter/AnalyzeContext.java
@@ -5,6 +5,7 @@ import org.amshove.natlint.api.IDiagnosticReporter;
 import org.amshove.natlint.api.LinterDiagnostic;
 import org.amshove.natlint.editorconfig.EditorConfig;
 import org.amshove.natparse.DiagnosticSeverity;
+import org.amshove.natparse.IDiagnostic;
 import org.amshove.natparse.natural.INaturalModule;
 import org.amshove.natparse.natural.project.NaturalFile;
 
@@ -39,7 +40,7 @@ class AnalyzeContext implements IAnalyzeContext
 	}
 
 	@Override
-	public void report(LinterDiagnostic diagnostic)
+	public void report(IDiagnostic diagnostic)
 	{
 		if (editorConfig == null)
 		{
@@ -71,6 +72,6 @@ class AnalyzeContext implements IAnalyzeContext
 		}
 
 		var newSeverity = DiagnosticSeverity.fromString(newSeverityName);
-		diagnosticReporter.report(diagnostic.withSeverity(newSeverity));
+		diagnosticReporter.report(newSeverity.wrapped(diagnostic));
 	}
 }

--- a/libs/natlint/src/main/java/org/amshove/natlint/linter/NaturalLinter.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/linter/NaturalLinter.java
@@ -1,6 +1,6 @@
 package org.amshove.natlint.linter;
 
-import org.amshove.natlint.api.LinterDiagnostic;
+import org.amshove.natparse.IDiagnostic;
 import org.amshove.natparse.ReadOnlyList;
 import org.amshove.natparse.natural.*;
 import org.amshove.natparse.natural.project.NaturalFileType;
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 
 public class NaturalLinter
 {
-	public ReadOnlyList<LinterDiagnostic> lint(INaturalModule module)
+	public ReadOnlyList<IDiagnostic> lint(INaturalModule module)
 	{
 		// We can not analyze DDMs because we don't have an AST for them
 		if (module.file().getFiletype() == NaturalFileType.DDM)
@@ -18,7 +18,7 @@ public class NaturalLinter
 		}
 
 		var linterContext = LinterContext.INSTANCE;
-		var diagnostics = new ArrayList<LinterDiagnostic>();
+		var diagnostics = new ArrayList<IDiagnostic>();
 		var analyzeContext = new AnalyzeContext(module, diagnostics::add);
 		linterContext.editorConfig().ifPresent(analyzeContext::setEditorConfig);
 

--- a/libs/natlint/src/test/java/org/amshove/natlint/linter/AbstractAnalyzerTest.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/linter/AbstractAnalyzerTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.amshove.natlint.api.AbstractAnalyzer;
 import org.amshove.natlint.api.DiagnosticDescription;
-import org.amshove.natlint.api.LinterDiagnostic;
 import org.amshove.natlint.editorconfig.EditorConfig;
 import org.amshove.natlint.editorconfig.EditorConfigParser;
 import org.amshove.natparse.IDiagnostic;
@@ -118,7 +117,7 @@ public abstract class AbstractAnalyzerTest
 			.contains(diagnosticDescription);
 	}
 
-	private ReadOnlyList<LinterDiagnostic> lint(NaturalFile file)
+	private ReadOnlyList<IDiagnostic> lint(NaturalFile file)
 	{
 		var module = parse(file);
 		LinterContext.INSTANCE.reset();
@@ -211,7 +210,7 @@ public abstract class AbstractAnalyzerTest
 
 		DiagnosticDescription description();
 
-		Executable checkAssertion(List<LinterDiagnostic> actualDiagnostics);
+		Executable checkAssertion(List<IDiagnostic> actualDiagnostics);
 
 		default boolean matches(IDiagnostic diagnostic)
 		{
@@ -222,7 +221,7 @@ public abstract class AbstractAnalyzerTest
 	protected record ExpectedDiagnostic(int line, DiagnosticDescription description) implements DiagnosticAssertion
 	{
 		@Override
-		public Executable checkAssertion(List<LinterDiagnostic> actualDiagnostics)
+		public Executable checkAssertion(List<IDiagnostic> actualDiagnostics)
 		{
 			return () -> assertThat(actualDiagnostics)
 				.as("Expected diagnostic %s to be present but was not", this)
@@ -243,7 +242,7 @@ public abstract class AbstractAnalyzerTest
 	protected record ExpectedDiagnosticWithMessage(int line, DiagnosticDescription description, String expectedMessage) implements DiagnosticAssertion
 	{
 		@Override
-		public Executable checkAssertion(List<LinterDiagnostic> actualDiagnostics)
+		public Executable checkAssertion(List<IDiagnostic> actualDiagnostics)
 		{
 			return () -> assertThat(actualDiagnostics)
 				.as("Expected diagnostic %s to be present but was not", this)
@@ -267,7 +266,7 @@ public abstract class AbstractAnalyzerTest
 	protected record ExpectedNoDiagnostic(int line, DiagnosticDescription description) implements DiagnosticAssertion
 	{
 		@Override
-		public Executable checkAssertion(List<LinterDiagnostic> actualDiagnostics)
+		public Executable checkAssertion(List<IDiagnostic> actualDiagnostics)
 		{
 			return () -> assertThat(actualDiagnostics)
 				.as("Expected diagnostic %s to not be present", this)
@@ -294,7 +293,7 @@ public abstract class AbstractAnalyzerTest
 		}
 
 		@Override
-		public Executable checkAssertion(List<LinterDiagnostic> actualDiagnostics)
+		public Executable checkAssertion(List<IDiagnostic> actualDiagnostics)
 		{
 			return () -> assertThat(actualDiagnostics)
 				.as("Expected no diagnostic with id %s", description.getId())
@@ -322,7 +321,7 @@ public abstract class AbstractAnalyzerTest
 		}
 
 		@Override
-		public Executable checkAssertion(List<LinterDiagnostic> actualDiagnostics)
+		public Executable checkAssertion(List<IDiagnostic> actualDiagnostics)
 		{
 			return () ->
 			{

--- a/libs/natparse/src/main/java/org/amshove/natparse/DiagnosticSeverity.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/DiagnosticSeverity.java
@@ -1,5 +1,7 @@
 package org.amshove.natparse;
 
+import java.nio.file.Path;
+
 public enum DiagnosticSeverity
 {
 	INFO(0),
@@ -27,5 +29,76 @@ public enum DiagnosticSeverity
 			case "ERROR" -> ERROR;
 			default -> throw new IllegalArgumentException("Invalid severity: " + sev);
 		};
+	}
+
+	public IDiagnostic wrapped(IDiagnostic diagnostic)
+	{
+		return new Wrapper(diagnostic);
+	}
+
+	private class Wrapper implements IDiagnostic
+	{
+
+		IDiagnostic inner;
+
+		public Wrapper(IDiagnostic inner)
+		{
+			this.inner = inner;
+		}
+
+		@Override
+		public String id()
+		{
+			return inner.id();
+		}
+
+		@Override
+		public String message()
+		{
+			return inner.message();
+		}
+
+		@Override
+		public DiagnosticSeverity severity()
+		{
+			return DiagnosticSeverity.this;
+		}
+
+		@Override
+		public ReadOnlyList<AdditionalDiagnosticInfo> additionalInfo()
+		{
+			return inner.additionalInfo();
+		}
+
+		@Override
+		public int offset()
+		{
+			return inner.offset();
+		}
+
+		@Override
+		public int offsetInLine()
+		{
+			return inner.offsetInLine();
+		}
+
+		@Override
+		public int line()
+		{
+			return inner.line();
+		}
+
+		@Override
+		public int length()
+		{
+			return inner.length();
+		}
+
+		@Override
+		public Path filePath()
+		{
+			return inner.filePath();
+		}
+
 	}
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
@@ -181,7 +181,7 @@ public enum SyntaxKind
 
 	// Loops
 	AVER(false, false, false),
-	COUNT(false, false, false),
+	COUNT(true, false, false),
 	MAX(false, false, false),
 	MIN(false, false, false),
 	NAVER(false, false, false),
@@ -189,7 +189,7 @@ public enum SyntaxKind
 	NMIN(false, false, false),
 	OLD(false, false, false),
 	SUM(false, false, false),
-	TOTAL(false, false, false),
+	TOTAL(true, false, false),
 
 	// Math
 	ABS(false, false, false),
@@ -217,7 +217,7 @@ public enum SyntaxKind
 	// Kcheck reserved keywords
 	ACCEPT(false, false, false),
 	ADD(false, false, false),
-	ALL(false, false, false),
+	ALL(true, false, false),
 	ANY(false, false, false),
 	ASSIGN(false, false, false),
 	AT(false, false, false),
@@ -854,6 +854,22 @@ public enum SyntaxKind
 	public boolean canBeIdentifier()
 	{
 		return canBeIdentifier;
+	}
+
+	public boolean canBe(SyntaxKind other)
+	{
+
+		if (other == this)
+		{
+			return true;
+		}
+
+		if (other.isIdentifier()) {
+			return this.canBeIdentifier();
+		} else {
+			return false;
+		}
+
 	}
 
 	public boolean isAttribute()

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
@@ -864,9 +864,12 @@ public enum SyntaxKind
 			return true;
 		}
 
-		if (other.isIdentifier()) {
+		if (other.isIdentifier())
+		{
 			return this.canBeIdentifier();
-		} else {
+		}
+		else
+		{
 			return false;
 		}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
@@ -180,6 +180,9 @@ public class SyntaxToken implements IPosition
 
 	public SyntaxToken withKind(SyntaxKind newKind)
 	{
+		if (newKind == this.kind) {
+			return this;
+		}
 		var newToken = new SyntaxToken(
 			newKind,
 			offset,
@@ -189,10 +192,7 @@ public class SyntaxToken implements IPosition
 			filePath
 		);
 		newToken.setDiagnosticPosition(diagnosticPosition);
-		if (kind != newKind)
-		{
-			newToken.originalKind = kind;
-		}
+		newToken.originalKind = kind;
 		return newToken;
 	}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
@@ -180,7 +180,8 @@ public class SyntaxToken implements IPosition
 
 	public SyntaxToken withKind(SyntaxKind newKind)
 	{
-		if (newKind == this.kind) {
+		if (newKind == this.kind)
+		{
 			return this;
 		}
 		var newToken = new SyntaxToken(

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/TokenList.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/TokenList.java
@@ -201,7 +201,7 @@ public class TokenList implements Iterable<SyntaxToken>
 	 */
 	public boolean consume(SyntaxKind kind)
 	{
-		if (!isAtEnd() && peek().kind() == kind)
+		if (!isAtEnd() && peek().kind().canBe(kind))
 		{
 			advance();
 			return true;

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IDefineData.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IDefineData.java
@@ -1,5 +1,7 @@
 package org.amshove.natparse.natural;
 
+import java.util.List;
+
 import org.amshove.natparse.ReadOnlyList;
 import org.amshove.natparse.natural.ddm.IDdmField;
 import org.jspecify.annotations.Nullable;
@@ -33,6 +35,8 @@ public interface IDefineData extends ISyntaxNode
 	ReadOnlyList<ITypedVariableNode> effectiveParameterInOrder();
 
 	ReadOnlyList<IVariableNode> variables();
+
+	List<IVariableNode> findVariablesWithName(String symbolName);
 
 	@Nullable
 	IVariableNode findVariable(String symbolName);

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
@@ -1,0 +1,11 @@
+package org.amshove.natparse.natural;
+
+import org.amshove.natparse.lexing.SyntaxToken;
+import org.jspecify.annotations.Nullable;
+
+public interface IIncDicNode extends IStatementNode
+{
+	@Nullable
+	SyntaxToken ruleName();
+}
+

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
@@ -8,4 +8,3 @@ public interface IIncDicNode extends IStatementNode
 	@Nullable
 	SyntaxToken ruleName();
 }
-

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
@@ -6,8 +6,8 @@ import org.jspecify.annotations.Nullable;
 /**
  * This node defines an "INCluded from DICtionary" rule
  *
- * This is either an inline rule in the body of the map program,
- * or a rule accessed from the FDIC file attached to the compiler
+ * This is either an inline rule in the body of the map program, or a rule accessed from the FDIC file attached to the
+ * compiler
  *
  */
 public interface IIncDicNode extends IStatementNode

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDicNode.java
@@ -3,6 +3,13 @@ package org.amshove.natparse.natural;
 import org.amshove.natparse.lexing.SyntaxToken;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * This node defines an "INCluded from DICtionary" rule
+ *
+ * This is either an inline rule in the body of the map program,
+ * or a rule accessed from the FDIC file attached to the compiler
+ *
+ */
 public interface IIncDicNode extends IStatementNode
 {
 	@Nullable

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
@@ -5,6 +5,7 @@ import org.amshove.natparse.lexing.SyntaxToken;
 public interface IIncDirNode extends IStatementNode
 {
 	SyntaxToken ddmName();
+
 	SyntaxToken fieldName();
 
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
@@ -1,4 +1,10 @@
 package org.amshove.natparse.natural;
 
+import org.amshove.natparse.lexing.SyntaxToken;
+
 public interface IIncDirNode extends IStatementNode
-{}
+{
+	SyntaxToken ddmName();
+	SyntaxToken fieldName();
+
+}

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
@@ -5,9 +5,8 @@ import org.amshove.natparse.lexing.SyntaxToken;
 /**
  * This node is an "INCluded from DIRectory" node
  *
- * These nodes are validation rules attached to the Adabas file / fields
- * by the DBA. Not clear whether these are inlined into the program at
- * compile time, or whether they just include a hook to call them
+ * These nodes are validation rules attached to the Adabas file / fields by the DBA. Not clear whether these are inlined
+ * into the program at compile time, or whether they just include a hook to call them
  *
  * The map editor just adds these automatically when you reference a view
  *

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IIncDirNode.java
@@ -2,6 +2,16 @@ package org.amshove.natparse.natural;
 
 import org.amshove.natparse.lexing.SyntaxToken;
 
+/**
+ * This node is an "INCluded from DIRectory" node
+ *
+ * These nodes are validation rules attached to the Adabas file / fields
+ * by the DBA. Not clear whether these are inlined into the program at
+ * compile time, or whether they just include a hook to call them
+ *
+ * The map editor just adds these automatically when you reference a view
+ *
+ */
 public interface IIncDirNode extends IStatementNode
 {
 	SyntaxToken ddmName();

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IRuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IRuleVarNode.java
@@ -1,4 +1,4 @@
 package org.amshove.natparse.natural;
 
-public interface IRuleVarNode extends IStatementNode
+public interface IRuleVarNode extends IStatementWithBodyNode
 {}

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IRuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IRuleVarNode.java
@@ -2,7 +2,8 @@ package org.amshove.natparse.natural;
 
 public interface IRuleVarNode extends IStatementWithBodyNode
 {
-	public enum Type {
+	public enum Type
+	{
 		FREE_RULE,
 		DICTIONARY_RULE
 	}

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IRuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IRuleVarNode.java
@@ -1,4 +1,11 @@
 package org.amshove.natparse.natural;
 
 public interface IRuleVarNode extends IStatementWithBodyNode
-{}
+{
+	public enum Type {
+		FREE_RULE,
+		DICTIONARY_RULE
+	}
+
+	public Type type();
+}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
@@ -190,9 +190,9 @@ abstract class AbstractParser<T>
 	 */
 	protected boolean consumeOptionally(BaseSyntaxNode node, SyntaxKind kind)
 	{
-		if (!tokens.isAtEnd() && tokens.peek().kind() == kind)
+		if (!tokens.isAtEnd() && tokens.peek().kind().canBe(kind))
 		{
-			previousNode = new TokenNode(tokens.peek());
+			previousNode = new TokenNode(tokens.peek().withKind(kind));
 			node.addNode(previousNode);
 		}
 
@@ -675,7 +675,8 @@ abstract class AbstractParser<T>
 		}
 
 		if ((peekKind(SyntaxKind.IDENTIFIER) || peek().kind().canBeIdentifier())
-			&& !peek().kind().isSystemVariable() && !peek().kind().isSystemFunction() && !peekKind(SyntaxKind.LOG))
+			&& !peek().kind().isSystemVariable() && !peek().kind().isSystemFunction()
+			&& !peekKind(SyntaxKind.LOG) && !peekKind(SyntaxKind.COUNT) && !peekKind(SyntaxKind.TOTAL))
 		{
 			if (peekKind(1, SyntaxKind.LPAREN) && (peekKind(2, SyntaxKind.LESSER_SIGN) || peekKind(2, SyntaxKind.LESSER_GREATER)))
 			{

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
@@ -1,0 +1,192 @@
+package org.amshove.natparse.parsing;
+
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.amshove.natparse.IPosition;
+import org.amshove.natparse.ReadOnlyList;
+import org.amshove.natparse.natural.IDefineData;
+import org.amshove.natparse.natural.IParameterDefinitionNode;
+import org.amshove.natparse.natural.IScopeNode;
+import org.amshove.natparse.natural.IStatementVisitor;
+import org.amshove.natparse.natural.ISyntaxNode;
+import org.amshove.natparse.natural.ISyntaxNodeVisitor;
+import org.amshove.natparse.natural.ITypedVariableNode;
+import org.amshove.natparse.natural.IUsingNode;
+import org.amshove.natparse.natural.IVariableNode;
+import org.amshove.natparse.natural.VariableScope;
+import org.amshove.natparse.natural.ddm.IDdmField;
+import org.jspecify.annotations.Nullable;
+
+class DefineDataNested implements IDefineData
+{
+
+	private IDefineData moduleDefine;
+	private IDefineData ruleDefine;
+	// Items that DefineDataNode implements
+
+	public DefineDataNested(IDefineData moduleDefine, IDefineData ruleDefine)
+	{
+		this.moduleDefine = moduleDefine;
+		this.ruleDefine = ruleDefine;
+	}
+
+	@Override
+	public List<IVariableNode> findVariablesWithName(String symbolName)
+	{
+		return Stream.concat(
+			ruleDefine.findVariablesWithName(symbolName).stream(),
+			moduleDefine.findVariablesWithName(symbolName).stream()
+		).toList();
+	}
+
+	@Override
+	public @Nullable IDdmField findDdmField(String symbolName)
+	{
+		var ddmField = ruleDefine.findDdmField(symbolName);
+		if (ddmField == null)
+		{
+			ddmField = moduleDefine.findDdmField(symbolName);
+		}
+		return ddmField;
+	}
+
+	@Override
+	public ReadOnlyList<IUsingNode> localUsings()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<IUsingNode> parameterUsings()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<IUsingNode> globalUsings()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<IParameterDefinitionNode> declaredParameterInOrder()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<IVariableNode> variables()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public @Nullable IVariableNode findVariable(String symbolName)
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public @Nullable IScopeNode findFirstScopeNode(VariableScope scope)
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public @Nullable ISyntaxNode findLastScopeNode(VariableScope scope)
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<IUsingNode> usings()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<ITypedVariableNode> effectiveParameterInOrder()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	// ISyntaxNode
+
+	@Override
+	public ISyntaxNode parent()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public IPosition diagnosticPosition()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public boolean isInFile(Path path)
+	{
+		throw new RuntimeException("Not implemented");
+		// return false;
+	}
+
+	@Override
+	public IPosition position()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public Iterator<ISyntaxNode> iterator()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public ReadOnlyList<? extends ISyntaxNode> descendants()
+	{
+		throw new RuntimeException("Not implemented");
+		// return null;
+	}
+
+	@Override
+	public void destroy()
+	{
+		throw new RuntimeException("Not implemented");
+
+	}
+
+	// ISyntaxTree
+
+	@Override
+	public void acceptNodeVisitor(ISyntaxNodeVisitor visitor)
+	{
+		throw new RuntimeException("Not implemented");
+
+	}
+
+	@Override
+	public void acceptStatementVisitor(IStatementVisitor visitor)
+	{
+		throw new RuntimeException("Not implemented");
+	}
+
+}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
@@ -20,7 +20,7 @@ import org.amshove.natparse.natural.VariableScope;
 import org.amshove.natparse.natural.ddm.IDdmField;
 import org.jspecify.annotations.Nullable;
 
-class DefineDataNested implements IDefineData
+class DefineDataNested extends BaseSyntaxNode implements IDefineData
 {
 
 	private IDefineData moduleDefine;

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
@@ -23,8 +23,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * A DEFINE DATA that is part of a RuleNode
  *
- * Inline rules can access everything in the upper scope of the map program
- * as well as locally defined variables.
+ * Inline rules can access everything in the upper scope of the map program as well as locally defined variables.
  *
  */
 class DefineDataNested extends BaseSyntaxNode implements IDefineData

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNested.java
@@ -20,6 +20,13 @@ import org.amshove.natparse.natural.VariableScope;
 import org.amshove.natparse.natural.ddm.IDdmField;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * A DEFINE DATA that is part of a RuleNode
+ *
+ * Inline rules can access everything in the upper scope of the map program
+ * as well as locally defined variables.
+ *
+ */
 class DefineDataNested extends BaseSyntaxNode implements IDefineData
 {
 
@@ -57,70 +64,59 @@ class DefineDataNested extends BaseSyntaxNode implements IDefineData
 	public ReadOnlyList<IUsingNode> localUsings()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public ReadOnlyList<IUsingNode> parameterUsings()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
-	@Override
 	public ReadOnlyList<IUsingNode> globalUsings()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public ReadOnlyList<IParameterDefinitionNode> declaredParameterInOrder()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public ReadOnlyList<IVariableNode> variables()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public @Nullable IVariableNode findVariable(String symbolName)
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public @Nullable IScopeNode findFirstScopeNode(VariableScope scope)
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public @Nullable ISyntaxNode findLastScopeNode(VariableScope scope)
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public ReadOnlyList<IUsingNode> usings()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public ReadOnlyList<ITypedVariableNode> effectiveParameterInOrder()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	// ISyntaxNode
@@ -129,42 +125,36 @@ class DefineDataNested extends BaseSyntaxNode implements IDefineData
 	public ISyntaxNode parent()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public IPosition diagnosticPosition()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public boolean isInFile(Path path)
 	{
 		throw new RuntimeException("Not implemented");
-		// return false;
 	}
 
 	@Override
 	public IPosition position()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public Iterator<ISyntaxNode> iterator()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override
 	public ReadOnlyList<? extends ISyntaxNode> descendants()
 	{
 		throw new RuntimeException("Not implemented");
-		// return null;
 	}
 
 	@Override

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataNode.java
@@ -199,7 +199,8 @@ class DefineDataNode extends BaseSyntaxNode implements IDefineData
 		}
 	}
 
-	List<IVariableNode> findVariablesWithName(String symbolName)
+	@Override
+	public List<IVariableNode> findVariablesWithName(String symbolName)
 	{
 		var foundVariables = new ArrayList<IVariableNode>();
 		for (var variable : variables)

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/IHasDefineNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/IHasDefineNode.java
@@ -1,0 +1,19 @@
+package org.amshove.natparse.parsing;
+
+import org.amshove.natparse.natural.IDefineData;
+
+/**
+ * Interface for nodes that can have a define node nested in them Ok, this is just INCDIC
+ */
+interface IHasDefineNode
+{
+	/**
+	 * Return true if the node actually has a define node
+	 */
+	public boolean hasDefineNode();
+
+	/**
+	 * Return the define node
+	 */
+	public IDefineData defineNode();
+}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDicNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDicNode.java
@@ -1,0 +1,37 @@
+package org.amshove.natparse.parsing;
+
+import org.amshove.natparse.lexing.SyntaxToken;
+import org.amshove.natparse.natural.IDefineData;
+import org.amshove.natparse.natural.IIncDicNode;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * INCDIC represents a validation rule reference
+ *
+ * This statement is also used just before an inline rule without a rule name
+ */
+class IncDicNode extends StatementWithBodyNode implements IIncDicNode
+{
+	private SyntaxToken ruleName;
+	private IDefineData define;
+
+	public void setRuleName(SyntaxToken ruleName)
+	{
+		this.ruleName = ruleName;
+	}
+
+	@Nullable
+	@Override
+	public SyntaxToken ruleName()
+	{
+	    return this.ruleName;
+	}
+
+	public void setDefine(IDefineData define)
+	{
+		this.define = define;
+	}
+
+
+}
+

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDicNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDicNode.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
  *
  * This statement is also used just before an inline rule without a rule name
  */
-class IncDicNode extends StatementWithBodyNode implements IIncDicNode
+class IncDicNode extends StatementWithBodyNode implements IIncDicNode, IHasDefineNode
 {
 	private SyntaxToken ruleName;
 	private IDefineData define;
@@ -24,7 +24,7 @@ class IncDicNode extends StatementWithBodyNode implements IIncDicNode
 	@Override
 	public SyntaxToken ruleName()
 	{
-	    return this.ruleName;
+		return this.ruleName;
 	}
 
 	public void setDefine(IDefineData define)
@@ -32,6 +32,16 @@ class IncDicNode extends StatementWithBodyNode implements IIncDicNode
 		this.define = define;
 	}
 
+	@Override
+	public boolean hasDefineNode()
+	{
+		return this.define != null;
+	}
+
+	@Override
+	public IDefineData defineNode()
+	{
+		return this.define;
+	}
 
 }
-

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDirNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDirNode.java
@@ -1,6 +1,40 @@
 package org.amshove.natparse.parsing;
 
+import org.amshove.natparse.lexing.SyntaxToken;
 import org.amshove.natparse.natural.IIncDirNode;
 
+/**
+ * INCDIR is always generated when you put a database field in a map
+ *
+ * CHKRULE=ON means the DDM and field name are checked to exist on build
+ * Not sure if this statement inlines rules from Predict into the compiled
+ * code, or whether it just inserts a callout to rules
+ */
 class IncDirNode extends StatementNode implements IIncDirNode
-{}
+{
+	private SyntaxToken ddmName;
+	private SyntaxToken fieldName;
+
+	public void setDdmName(SyntaxToken ddmName)
+	{
+		this.ddmName = ddmName;
+	}
+
+	public void setFieldName(SyntaxToken fieldName)
+	{
+		this.fieldName = fieldName;
+	}
+
+	@Override
+	public SyntaxToken ddmName()
+	{
+	    return this.ddmName;
+	}
+
+	@Override
+	public SyntaxToken fieldName()
+	{
+	    return this.fieldName;
+	}
+
+}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDirNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/IncDirNode.java
@@ -6,9 +6,8 @@ import org.amshove.natparse.natural.IIncDirNode;
 /**
  * INCDIR is always generated when you put a database field in a map
  *
- * CHKRULE=ON means the DDM and field name are checked to exist on build
- * Not sure if this statement inlines rules from Predict into the compiled
- * code, or whether it just inserts a callout to rules
+ * CHKRULE=ON means the DDM and field name are checked to exist on build Not sure if this statement inlines rules from
+ * Predict into the compiled code, or whether it just inserts a callout to rules
  */
 class IncDirNode extends StatementNode implements IIncDirNode
 {
@@ -28,13 +27,13 @@ class IncDirNode extends StatementNode implements IIncDirNode
 	@Override
 	public SyntaxToken ddmName()
 	{
-	    return this.ddmName;
+		return this.ddmName;
 	}
 
 	@Override
 	public SyntaxToken fieldName()
 	{
-	    return this.fieldName;
+		return this.fieldName;
 	}
 
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/NaturalModuleBuilder.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/NaturalModuleBuilder.java
@@ -70,6 +70,19 @@ public class NaturalModuleBuilder
 		return defineData;
 	}
 
+	IDefineData getDefineData(ISyntaxNode scopeNode)
+	{
+		while (scopeNode.parent() != null)
+		{
+			scopeNode = scopeNode.parent();
+			if (scopeNode instanceof IHasDefineNode && ((IHasDefineNode) scopeNode).hasDefineNode())
+			{
+				return new DefineDataNested(defineData, ((IHasDefineNode) scopeNode).defineNode());
+			}
+		}
+		return defineData;
+	}
+
 	IStatementListNode body()
 	{
 		return body;

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/NaturalParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/NaturalParser.java
@@ -298,6 +298,8 @@ public class NaturalParser
 		var unresolvedAdabasArrayAccess = new ArrayList<ISymbolReferenceNode>();
 		for (var unresolvedReference : statementParser.unresolvedSymbols())
 		{
+			defineData = moduleBuilder.getDefineData(unresolvedReference);
+
 			if (unresolvedReference.parent() instanceof IAdabasIndexAccess)
 			{
 				unresolvedAdabasArrayAccess.add(unresolvedReference); // needs to be re-evaluated after, because it's parents need to be resolved
@@ -408,7 +410,7 @@ public class NaturalParser
 
 	private boolean tryFindAndReference(String symbolName, ISymbolReferenceNode referenceNode, IDefineData defineData, NaturalModuleBuilder moduleBuilder)
 	{
-		var foundVariables = ((DefineDataNode) defineData).findVariablesWithName(symbolName);
+		var foundVariables = defineData.findVariablesWithName(symbolName);
 
 		if (foundVariables.size() > 1)
 		{

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/NaturalParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/NaturalParser.java
@@ -298,6 +298,8 @@ public class NaturalParser
 		var unresolvedAdabasArrayAccess = new ArrayList<ISymbolReferenceNode>();
 		for (var unresolvedReference : statementParser.unresolvedSymbols())
 		{
+			defineData = moduleBuilder.getDefineData(unresolvedReference);
+
 			if (unresolvedReference.parent() instanceof IAdabasIndexAccess)
 			{
 				unresolvedAdabasArrayAccess.add(unresolvedReference); // needs to be re-evaluated after, because it's parents need to be resolved
@@ -454,7 +456,7 @@ public class NaturalParser
 				}
 			}
 
-		var foundVariables = ((DefineDataNode) defineData).findVariablesWithName(symbolName);
+		var foundVariables = defineData.findVariablesWithName(symbolName);
 
 		if (foundVariables.size() > 1)
 		{

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
@@ -1,6 +1,27 @@
 package org.amshove.natparse.parsing;
 
+import org.amshove.natparse.lexing.SyntaxToken;
 import org.amshove.natparse.natural.IRuleVarNode;
 
-class RuleVarNode extends StatementNode implements IRuleVarNode
-{}
+class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode {
+
+	private SyntaxToken nameToken;
+
+	private IncDirNode incDirNode;
+	// OR
+	private IncDicNode incDicNode;
+
+	void setName(SyntaxToken nameToken)
+	{
+		this.nameToken = nameToken;
+	}
+
+	void setIncDir(IncDirNode incDirNode) {
+		this.incDirNode = incDirNode;
+	}
+
+	void setIncDic(IncDicNode incDicNode) {
+		this.incDicNode = incDicNode;
+	}
+
+}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
@@ -3,7 +3,8 @@ package org.amshove.natparse.parsing;
 import org.amshove.natparse.lexing.SyntaxToken;
 import org.amshove.natparse.natural.IRuleVarNode;
 
-class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode {
+class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode
+{
 
 	private SyntaxToken nameToken;
 
@@ -16,11 +17,13 @@ class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode {
 		this.nameToken = nameToken;
 	}
 
-	void setIncDir(IncDirNode incDirNode) {
+	void setIncDir(IncDirNode incDirNode)
+	{
 		this.incDirNode = incDirNode;
 	}
 
-	void setIncDic(IncDicNode incDicNode) {
+	void setIncDic(IncDicNode incDicNode)
+	{
 		this.incDicNode = incDicNode;
 	}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
@@ -29,11 +29,13 @@ class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode
 		this.incDicNode = incDicNode;
 	}
 
-	void setType(Type type) {
+	void setType(Type type)
+	{
 		this.type = type;
 	}
 
-	public Type type() {
+	public Type type()
+	{
 		return this.type;
 	}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/RuleVarNode.java
@@ -6,6 +6,8 @@ import org.amshove.natparse.natural.IRuleVarNode;
 class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode
 {
 
+	private Type type;
+
 	private SyntaxToken nameToken;
 
 	private IncDirNode incDirNode;
@@ -25,6 +27,14 @@ class RuleVarNode extends StatementWithBodyNode implements IRuleVarNode
 	void setIncDic(IncDicNode incDicNode)
 	{
 		this.incDicNode = incDicNode;
+	}
+
+	void setType(Type type) {
+		this.type = type;
+	}
+
+	public Type type() {
+		return this.type;
 	}
 
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -4618,8 +4618,15 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 	{
 		var node = new RuleVarNode();
 		consumeMandatory(node, SyntaxKind.RULEVAR);
-		while (!isAtEnd() && !isStatementStart())
-		{
+		node.setName(consumeMandatoryIdentifier(node));
+
+		if (peekKind(SyntaxKind.INCDIR)) {
+			node.setIncDir(incdir());
+		} else if (peekKind(SyntaxKind.INCDIC)) {
+			node.setIncDic(incdic());
+		}
+
+		while (!isAtEnd() && !isStatementStart()) {
 			consume(node);
 		}
 
@@ -4630,9 +4637,38 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 	{
 		var node = new IncDirNode();
 		consumeMandatory(node, SyntaxKind.INCDIR);
-		while (!isAtEnd() && !isStatementStart())
+		SyntaxToken ddmName = consumeMandatory(node, SyntaxKind.IDENTIFIER);
+		node.setDdmName(ddmName);
+		SyntaxToken fieldName = consumeMandatory(node, SyntaxKind.IDENTIFIER);
+		node.setFieldName(fieldName);
+		consumeMandatory(node, SyntaxKind.SEMICOLON);
+
+		return node;
+	}
+
+	private IncDicNode incdic() throws ParseError
+	{
+		var node = new IncDicNode();
+		consumeMandatory(node, SyntaxKind.INCDIC);
+
+		SyntaxToken ruleName = null;
+		if (peekKind(SyntaxKind.IDENTIFIER)) {
+			ruleName = consumeMandatoryIdentifier(node);
+			node.setRuleName(ruleName);
+		}
+		consumeMandatory(node, SyntaxKind.SEMICOLON);
+
+		if (ruleName == null)
 		{
-			consume(node);
+			// Inline rule
+			if (peekKind(SyntaxKind.DEFINE))
+			{
+				// with a define block
+				var defineDataParser = new DefineDataParser(this.moduleProvider);
+				var defineBlock = defineDataParser.parse((tokens));
+				node.setDefine(defineBlock.result());
+			}
+			node.setBody(statementList(Set.of(SyntaxKind.RULEVAR, SyntaxKind.END)));
 		}
 
 		return node;

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -4531,6 +4531,7 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		var opening = consumeMandatory(work, SyntaxKind.READ);
 		consumeMandatory(work, SyntaxKind.WORK);
 		consumeOptionally(work, SyntaxKind.FILE);
+		// TODO: This operand can also accept a constant variable
 		var number = consumeNonConcatLiteralNode(work, SyntaxKind.NUMBER_LITERAL);
 		checkNumericRange(number, 1, 32);
 		work.setWorkFileNumber(number);
@@ -4620,13 +4621,18 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		consumeMandatory(node, SyntaxKind.RULEVAR);
 		node.setName(consumeMandatoryIdentifier(node));
 
-		if (peekKind(SyntaxKind.INCDIR)) {
+		if (peekKind(SyntaxKind.INCDIR))
+		{
 			node.setIncDir(incdir());
-		} else if (peekKind(SyntaxKind.INCDIC)) {
-			node.setIncDic(incdic());
 		}
+		else
+			if (peekKind(SyntaxKind.INCDIC))
+			{
+				node.setIncDic(incdic());
+			}
 
-		while (!isAtEnd() && !isStatementStart()) {
+		while (!isAtEnd() && !isStatementStart())
+		{
 			consume(node);
 		}
 
@@ -4652,7 +4658,8 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		consumeMandatory(node, SyntaxKind.INCDIC);
 
 		SyntaxToken ruleName = null;
-		if (peekKind(SyntaxKind.IDENTIFIER)) {
+		if (peekKind(SyntaxKind.IDENTIFIER))
+		{
 			ruleName = consumeMandatoryIdentifier(node);
 			node.setRuleName(ruleName);
 		}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -22,6 +22,7 @@ import org.amshove.natparse.natural.ILiteralNode;
 import org.amshove.natparse.natural.IMaskOperandNode;
 import org.amshove.natparse.natural.IOperandNode;
 import org.amshove.natparse.natural.IReferencableNode;
+import org.amshove.natparse.natural.IRuleVarNode;
 import org.amshove.natparse.natural.IStatementListNode;
 import org.amshove.natparse.natural.IStatementWithBodyNode;
 import org.amshove.natparse.natural.ISymbolReferenceNode;
@@ -4745,7 +4746,23 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 	{
 		var node = new RuleVarNode();
 		consumeMandatory(node, SyntaxKind.RULEVAR);
-		node.setName(consumeMandatoryIdentifier(node));
+		var nodeIdentifier = consumeMandatoryIdentifier(node);
+
+		if (nodeIdentifier.source().charAt(0) == 'F') {
+			node.setType(IRuleVarNode.Type.FREE_RULE);
+		} else if (nodeIdentifier.source().charAt(0) == 'D') {
+			node.setType(IRuleVarNode.Type.DICTIONARY_RULE);
+		} else {
+			report(ParserErrors.unexpectedToken(nodeIdentifier, "RULEVAR should have F or D type"));
+		}
+
+		int index = Integer.parseInt(nodeIdentifier.source().substring(1, 3));
+
+		if (nodeIdentifier.source().length() == 3) {
+			// This happens when the identifier is F00*PF-KEY and it splits
+			// We need to eat the PF-KEY
+			consumeMandatory(node, SyntaxKind.SV_PF_KEY);
+		}
 
 		if (peekKind(SyntaxKind.INCDIR))
 		{

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -4744,8 +4744,15 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 	{
 		var node = new RuleVarNode();
 		consumeMandatory(node, SyntaxKind.RULEVAR);
-		while (!isAtEnd() && !isStatementStart())
-		{
+		node.setName(consumeMandatoryIdentifier(node));
+
+		if (peekKind(SyntaxKind.INCDIR)) {
+			node.setIncDir(incdir());
+		} else if (peekKind(SyntaxKind.INCDIC)) {
+			node.setIncDic(incdic());
+		}
+
+		while (!isAtEnd() && !isStatementStart()) {
 			consume(node);
 		}
 
@@ -4756,9 +4763,38 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 	{
 		var node = new IncDirNode();
 		consumeMandatory(node, SyntaxKind.INCDIR);
-		while (!isAtEnd() && !isStatementStart())
+		SyntaxToken ddmName = consumeMandatory(node, SyntaxKind.IDENTIFIER);
+		node.setDdmName(ddmName);
+		SyntaxToken fieldName = consumeMandatory(node, SyntaxKind.IDENTIFIER);
+		node.setFieldName(fieldName);
+		consumeMandatory(node, SyntaxKind.SEMICOLON);
+
+		return node;
+	}
+
+	private IncDicNode incdic() throws ParseError
+	{
+		var node = new IncDicNode();
+		consumeMandatory(node, SyntaxKind.INCDIC);
+
+		SyntaxToken ruleName = null;
+		if (peekKind(SyntaxKind.IDENTIFIER)) {
+			ruleName = consumeMandatoryIdentifier(node);
+			node.setRuleName(ruleName);
+		}
+		consumeMandatory(node, SyntaxKind.SEMICOLON);
+
+		if (ruleName == null)
 		{
-			consume(node);
+			// Inline rule
+			if (peekKind(SyntaxKind.DEFINE))
+			{
+				// with a define block
+				var defineDataParser = new DefineDataParser(this.moduleProvider);
+				var defineBlock = defineDataParser.parse((tokens));
+				node.setDefine(defineBlock.result());
+			}
+			node.setBody(statementList(Set.of(SyntaxKind.RULEVAR, SyntaxKind.END)));
 		}
 
 		return node;

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -4748,17 +4748,24 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		consumeMandatory(node, SyntaxKind.RULEVAR);
 		var nodeIdentifier = consumeMandatoryIdentifier(node);
 
-		if (nodeIdentifier.source().charAt(0) == 'F') {
+		if (nodeIdentifier.source().charAt(0) == 'F')
+		{
 			node.setType(IRuleVarNode.Type.FREE_RULE);
-		} else if (nodeIdentifier.source().charAt(0) == 'D') {
-			node.setType(IRuleVarNode.Type.DICTIONARY_RULE);
-		} else {
-			report(ParserErrors.unexpectedToken(nodeIdentifier, "RULEVAR should have F or D type"));
 		}
+		else
+			if (nodeIdentifier.source().charAt(0) == 'D')
+			{
+				node.setType(IRuleVarNode.Type.DICTIONARY_RULE);
+			}
+			else
+			{
+				report(ParserErrors.unexpectedToken(nodeIdentifier, "RULEVAR should have F or D type"));
+			}
 
 		int index = Integer.parseInt(nodeIdentifier.source().substring(1, 3));
 
-		if (nodeIdentifier.source().length() == 3) {
+		if (nodeIdentifier.source().length() == 3)
+		{
 			// This happens when the identifier is F00*PF-KEY and it splits
 			// We need to eat the PF-KEY
 			consumeMandatory(node, SyntaxKind.SV_PF_KEY);

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/StatementListParser.java
@@ -4657,6 +4657,7 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		var opening = consumeMandatory(work, SyntaxKind.READ);
 		consumeMandatory(work, SyntaxKind.WORK);
 		consumeOptionally(work, SyntaxKind.FILE);
+		// TODO: This operand can also accept a constant variable
 		var number = consumeNonConcatLiteralNode(work, SyntaxKind.NUMBER_LITERAL);
 		checkNumericRange(number, 1, 32);
 		work.setWorkFileNumber(number);
@@ -4746,13 +4747,18 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		consumeMandatory(node, SyntaxKind.RULEVAR);
 		node.setName(consumeMandatoryIdentifier(node));
 
-		if (peekKind(SyntaxKind.INCDIR)) {
+		if (peekKind(SyntaxKind.INCDIR))
+		{
 			node.setIncDir(incdir());
-		} else if (peekKind(SyntaxKind.INCDIC)) {
-			node.setIncDic(incdic());
 		}
+		else
+			if (peekKind(SyntaxKind.INCDIC))
+			{
+				node.setIncDic(incdic());
+			}
 
-		while (!isAtEnd() && !isStatementStart()) {
+		while (!isAtEnd() && !isStatementStart())
+		{
 			consume(node);
 		}
 
@@ -4778,7 +4784,8 @@ public class StatementListParser extends AbstractParser<IStatementListNode>
 		consumeMandatory(node, SyntaxKind.INCDIC);
 
 		SyntaxToken ruleName = null;
-		if (peekKind(SyntaxKind.IDENTIFIER)) {
+		if (peekKind(SyntaxKind.IDENTIFIER))
+		{
 			ruleName = consumeMandatoryIdentifier(node);
 			node.setRuleName(ruleName);
 		}

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/StatementListParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/StatementListParserShould.java
@@ -4036,9 +4036,11 @@ class StatementListParserShould extends StatementParseTest
 	@Test
 	void consumeIncDir()
 	{
-		assertParsesSingleStatement("""
-               INCDIR #VAR #VAR1 #VAR2;
+		var incdirNode = assertParsesSingleStatement("""
+               INCDIR DDMNAME FIELDNAME ;
             """, IIncDirNode.class);
+		assertThat(incdirNode.ddmName().source()).isEqualTo("DDMNAME");
+		assertThat(incdirNode.fieldName().source()).isEqualTo("FIELDNAME");
 	}
 
 	@Test

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/StatementListParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/StatementListParserShould.java
@@ -1912,6 +1912,13 @@ class StatementListParserShould extends StatementParseTest
 	}
 
 	@Test
+	void parseFormatWithIdentifier()
+	{
+		var statementList = assertParsesWithoutDiagnostics("FORMAT (REPORT) LS=5 ZP=ON");
+		assertThat(statementList.statements().size()).isEqualTo(1);
+	}
+
+	@Test
 	void parseFormatIfNextLineStartsWithStatement()
 	{
 		// If a format thingy is empty, the next line should still properly be identified as the next statement

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/StatementListParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/StatementListParserShould.java
@@ -4044,14 +4044,6 @@ class StatementListParserShould extends StatementParseTest
 	}
 
 	@Test
-	void consumeRuleVar()
-	{
-		assertParsesSingleStatement("""
-               RULEVAR DDM.FIELD;
-            """, IRuleVarNode.class);
-	}
-
-	@Test
 	void parseSimpleEndTransaction()
 	{
 		var et = assertParsesSingleStatement("END TRANSACTION", IEndTransactionNode.class);

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/statements/RuleVarStatementParsingShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/statements/RuleVarStatementParsingShould.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
-class RuleVarStatementParsingShould extends StatementParseTest {
+class RuleVarStatementParsingShould extends StatementParseTest
+{
 
 	@Test
 	void consumeRuleVar()

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/statements/RuleVarStatementParsingShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/statements/RuleVarStatementParsingShould.java
@@ -1,0 +1,39 @@
+package org.amshove.natparse.parsing.statements;
+
+import org.amshove.natparse.natural.IRuleVarNode;
+import org.amshove.natparse.parsing.StatementParseTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class RuleVarStatementParsingShould extends StatementParseTest {
+
+	@Test
+	void consumeRuleVar()
+	{
+		assertParsesSingleStatement("""
+               RULEVAR F01L-VARIABLE
+            """, IRuleVarNode.class);
+	}
+
+	@Test
+	void ruleVarHasType()
+	{
+		var ruleVar = assertParsesSingleStatement("""
+               RULEVAR F01L-VARIABLE
+            """, IRuleVarNode.class);
+
+		assertThat(ruleVar.type()).isEqualTo(IRuleVarNode.Type.FREE_RULE);
+	}
+
+	@Test
+	void ruleVarForPfKey()
+	{
+		var ruleVar = assertParsesSingleStatement("""
+               RULEVAR F01*PF-KEY
+            """, IRuleVarNode.class);
+
+		assertThat(ruleVar.type()).isEqualTo(IRuleVarNode.Type.FREE_RULE);
+	}
+
+}


### PR DESCRIPTION
Vast majority of (wrong) lints in our codebase come from map rules ... so starting some map parsing

Map rules start 

```
RULEVAR RULENAMEIDENTIFIER
```

And then
```
{
INCDIR  DDMNAME   FIELDNAME   ;
|
INCDIC FREERULENAME          ;
|
INCDIC                    ;
}
```

The `RULEVAR` continues until another `RULEVAR` starts, or a normal object end happens.

- `INCDIR` means "use the Predict rule for this Adabas field"
    - These rules get added to views of Adabas files in maps [automatically](https://documentation.softwareag.com/natux/9.3.3/en/webhelp/natux-webhelp/mc/mcERRN_0700.htm#mcERRN_0721_NAT0721)
    - These are possibly what the docs call "Predict automatic rules"
    - Not sure if this inlines the code in the compiled object or calls out to some kind of hook
    - The (only)? check possible here is that the field exists in the named DDM
- `INCDIR` with a name is a Predict Free Rule
    - These make the compiler inline a chunk of code stored in a Predict Verification in your FDIC database
    - Without having a local copy of the code, doing any work with these is awkward
- `INCDIR` with no name is an inline rule
    - These are the source of the trouble
    
 Inline rules are effectively a nested program. Inline rules are allowed their own `DEFINE DATA` block.
 
 Inline rules may access all the variables in the scope of the current map **plus** any variables declared in their own block.
 
 ---
 
 Where this branch is right now ....
 
- Added DDM  and field, properties for the `INCDIR` nodes
- Made `INCDIC` nodes a node-with-body
- Added a define block parser to `INCDIC` nodes
- Added a means for variable resolution to find variables in the current scoped DEFINE block in rules

What needs to be added

- Hover no longer works (nor "goto def" etc), the nodes in the rule programs aren't working right.