### PR TITLE
Add the option to set the input source encoding

### DIFF
--- a/libs/natlint/src/main/java/org/amshove/natlint/cli/AnalyzeCommand.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/cli/AnalyzeCommand.java
@@ -34,6 +34,12 @@ public class AnalyzeCommand implements Callable<Integer>
 
 	@CommandLine.Option(names =
 	{
+		"--encoding"
+	}, description = "Encoding of the source code files", defaultValue = "UTF-8")
+	String encoding;
+
+	@CommandLine.Option(names =
+	{
 		"-r", "--relative"
 	}, description = "Only analyze modules matching any of the relative paths. Path should be relative to project root.")
 	List<String> relativePaths;
@@ -213,7 +219,8 @@ public class AnalyzeCommand implements Callable<Integer>
 			fileStatusMode ? FileStatusSink.create() : FileStatusSink.dummy(),
 			predicates,
 			disableLinting,
-			outputFlags
+			outputFlags,
+			encoding
 		);
 	}
 

--- a/libs/natlint/src/main/java/org/amshove/natlint/cli/CliAnalyzer.java
+++ b/libs/natlint/src/main/java/org/amshove/natlint/cli/CliAnalyzer.java
@@ -39,11 +39,11 @@ public class CliAnalyzer
 	private final AnalyzerOutputFlags outputFlags;
 	private Map<String, AtomicInteger> totalDiagnosticsById = new HashMap<>();
 
-	public CliAnalyzer(Path workingDirectory, IDiagnosticSink sink, FileStatusSink fileStatusSink, AnalyzerPredicates predicates, boolean disableLinting, AnalyzerOutputFlags outputFlags)
+	public CliAnalyzer(Path workingDirectory, IDiagnosticSink sink, FileStatusSink fileStatusSink, AnalyzerPredicates predicates, boolean disableLinting, AnalyzerOutputFlags outputFlags, String sourceEncoding)
 	{
 		this.workingDirectory = workingDirectory;
 		this.predicates = predicates;
-		filesystem = new ActualFilesystem();
+		filesystem = new ActualFilesystem(sourceEncoding);
 		diagnosticSink = sink;
 		this.fileStatusSink = fileStatusSink;
 		this.disableLinting = disableLinting;
@@ -52,8 +52,6 @@ public class CliAnalyzer
 
 	public int run()
 	{
-		var filesystem = new ActualFilesystem();
-
 		while (!workingDirectory.getRoot().equals(workingDirectory) && filesystem.findNaturalProjectFile(workingDirectory).isEmpty())
 		{
 			workingDirectory = workingDirectory.getParent();

--- a/libs/natparse/src/main/java/org/amshove/natparse/infrastructure/ActualFilesystem.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/infrastructure/ActualFilesystem.java
@@ -2,6 +2,8 @@ package org.amshove.natparse.infrastructure;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,6 +13,25 @@ import java.util.stream.Stream;
 
 public class ActualFilesystem implements IFilesystem
 {
+
+	Charset charset;
+
+	public ActualFilesystem()
+	{
+		this("UTF-8");
+	}
+
+	public ActualFilesystem(String charset)
+	{
+		this.charset = Charset.forName(charset, StandardCharsets.UTF_8);
+	}
+
+	@Override
+	public String toString()
+	{
+		return "ActualFilesystem[encoding=%s]".formatted(charset);
+	}
+
 	private static final String[] PROJECT_FILE_NAMES = new String[]
 	{
 		".natural", "_naturalBuild"
@@ -20,7 +41,7 @@ public class ActualFilesystem implements IFilesystem
 	{
 		try
 		{
-			return Files.readString(path);
+			return Files.readString(path, charset);
 		}
 		catch (IOException e)
 		{
@@ -79,7 +100,7 @@ public class ActualFilesystem implements IFilesystem
 	{
 		try
 		{
-			return Files.lines(path);
+			return Files.lines(path, charset);
 		}
 		catch (IOException e)
 		{


### PR DESCRIPTION
At the moment I am filtering my source tree to inline Predict rules into maps - finding that this stops the Natural nucleus segfaulting when running tests with `COVERAGE=(ACTIVE=ON)`.

Also shifting the encoding to ISO-8859-1 at the same time to replicate the exact files that NDV places into `fuser/` when pushing to NDV, but `natlint` chokes on these as input files.

Patch allows setting the input encoding of `natlint` as a CLI option.