### PR TITLE
Fix setup of libraries that have digits in their names

### DIFF
--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/project/XmlLibraryVisitor.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/project/XmlLibraryVisitor.java
@@ -44,7 +44,7 @@ class XmlLibraryVisitor implements Visitor
 		if (currentLibrary != null)
 		{
 			var steplibs = node.getStringValue();
-			steplibs = steplibs.replaceAll("\\d", "");
+			steplibs = steplibs.replace("^\\d+;", ";");
 			steplibs = steplibs.replaceAll("\\[.*?]", "");
 			Arrays.stream(steplibs.split(";"))
 				.filter(lib -> !lib.isEmpty())


### PR DESCRIPTION
Fixes a bug in steplib parsing that eliminates all digits from steplib names read from the `.natural` file.

This makes it impossible to find modules in libraries with digits in their names.

These modules are in a library called `SISNIN2`

Before
<img width="840" height="263" alt="Screenshot 2026-07-24 165714" src="https://github.com/user-attachments/assets/e7b0ec1c-d702-4cbd-873c-312a4fd3d3d8" />

After
<img width="701" height="217" alt="Screenshot 2026-07-24 165731" src="https://github.com/user-attachments/assets/636ab7d0-1657-48e0-9cd4-981c8d0b8522" />
