### PR TITLE
Support unicode String literals

### DIFF
--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
@@ -2,6 +2,8 @@ package org.amshove.natlint.analyzers;
 
 import org.amshove.natlint.linter.AbstractAnalyzerTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 {
@@ -67,6 +69,62 @@ class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 			#A1 := 'AB'
 			END
 			""", expectDiagnostic(3, ValueTruncationAnalyzer.VALUE_TRUNCATED));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"'AB'",
+		"H'4142'",
+		"U'AB'",
+		"UH'00410042'"
+	})
+	void reportADiagnosticWhenAlphaTruncatesAlphaFamily(String value)
+	{
+		testDiagnostics("""
+			DEFINE DATA LOCAL
+			1 #A1 (A1)
+			END-DEFINE
+			#A1 := %s
+			END
+			""".formatted(value), expectDiagnostic(3, ValueTruncationAnalyzer.VALUE_TRUNCATED));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"'AB'",
+		"H'4142'",
+		"U'AB'",
+		"UH'00410042'"
+	})
+	void reportADiagnosticWhenUnicodeTruncatesAlphaFamily(String value)
+	{
+		testDiagnostics("""
+			DEFINE DATA LOCAL
+			1 #U1 (U1)
+			END-DEFINE
+			#U1 := %s
+			END
+			""".formatted(value), expectDiagnostic(3, ValueTruncationAnalyzer.VALUE_TRUNCATED));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"'AB'",
+		"H'4142'",
+		"U'A'",
+		"U'AB'",
+		"UH'0041'",
+		"UH'00410042'"
+	})
+	void reportDiagnosticWhenStringsTruncatedByBinary(String value)
+	{
+		testDiagnostics("""
+			DEFINE DATA LOCAL
+			1 #B1 (B1)
+			END-DEFINE
+			#B1 := %s
+			END
+			""".formatted(value), expectDiagnostic(3, ValueTruncationAnalyzer.VALUE_TRUNCATED));
 	}
 
 	protected ValueTruncationAnalyzerShould()

--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
@@ -11,7 +11,8 @@ class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 	@Test
 	void reportThatAnythingFitsInADynamic()
 	{
-		testDiagnostics("""
+		testDiagnostics(
+			"""
 			DEFINE DATA LOCAL
 			01 #A-HOLE (A) DYNAMIC
 			01 #U-HOLE (U) DYNAMIC
@@ -23,10 +24,7 @@ class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 			#B-HOLE := H'42'
 
 			END
-			"""
-			, expectNoDiagnostic(6, ValueTruncationAnalyzer.VALUE_TRUNCATED)
-			, expectNoDiagnostic(7, ValueTruncationAnalyzer.VALUE_TRUNCATED)
-			, expectNoDiagnostic(8, ValueTruncationAnalyzer.VALUE_TRUNCATED)
+			""", expectNoDiagnostic(6, ValueTruncationAnalyzer.VALUE_TRUNCATED), expectNoDiagnostic(7, ValueTruncationAnalyzer.VALUE_TRUNCATED), expectNoDiagnostic(8, ValueTruncationAnalyzer.VALUE_TRUNCATED)
 
 		);
 	}

--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
@@ -72,7 +72,8 @@ class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(strings =
+	{
 		"'AB'",
 		"H'4142'",
 		"U'AB'",
@@ -90,7 +91,8 @@ class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(strings =
+	{
 		"'AB'",
 		"H'4142'",
 		"U'AB'",
@@ -108,7 +110,8 @@ class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(strings =
+	{
 		"'AB'",
 		"H'4142'",
 		"U'A'",

--- a/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
+++ b/libs/natlint/src/test/java/org/amshove/natlint/analyzers/ValueTruncationAnalyzerShould.java
@@ -7,6 +7,30 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class ValueTruncationAnalyzerShould extends AbstractAnalyzerTest
 {
+
+	@Test
+	void reportThatAnythingFitsInADynamic()
+	{
+		testDiagnostics("""
+			DEFINE DATA LOCAL
+			01 #A-HOLE (A) DYNAMIC
+			01 #U-HOLE (U) DYNAMIC
+			01 #B-HOLE (B) DYNAMIC
+			END-DEFINE
+
+			#A-HOLE := 'A'
+			#U-HOLE := 'U'
+			#B-HOLE := H'42'
+
+			END
+			"""
+			, expectNoDiagnostic(6, ValueTruncationAnalyzer.VALUE_TRUNCATED)
+			, expectNoDiagnostic(7, ValueTruncationAnalyzer.VALUE_TRUNCATED)
+			, expectNoDiagnostic(8, ValueTruncationAnalyzer.VALUE_TRUNCATED)
+
+		);
+	}
+
 	@Test
 	void raiseADiagnosticWhenAConstInitializerIsTruncatedForCompatibleFormats()
 	{

--- a/libs/natls/src/test/java/org/amshove/natls/FindConstantsEndpointShould.java
+++ b/libs/natls/src/test/java/org/amshove/natls/FindConstantsEndpointShould.java
@@ -50,6 +50,8 @@ class FindConstantsEndpointShould extends EmptyProjectTest
 			1 C-N (N1) CONST<2>
 			1 C-L (L) CONST<TRUE>
 			1 C-CONCAT (A6) CONST<'abc' - 'def'>
+			1 U-CONCAT (U6) CONST <U'abc' - U'def'>
+			1 UH-CONCAT (U6) CONST <UH'00410042' - U'CDEF'>
 			END-DEFINE
 			""");
 
@@ -60,12 +62,14 @@ class FindConstantsEndpointShould extends EmptyProjectTest
 			""");
 
 		var response = getContext().server().findConstants(new FindConstantsParams(identifier)).get(1, TimeUnit.MINUTES);
-		assertThat(response.getConstants()).hasSize(4);
+		assertThat(response.getConstants()).hasSize(6);
 
 		assertConstantWithValue(response, "C-A", "'A'");
 		assertConstantWithValue(response, "C-N", "2");
 		assertConstantWithValue(response, "C-L", "TRUE");
 		assertConstantWithValue(response, "C-CONCAT", "'abcdef'");
+		assertConstantWithValue(response, "U-CONCAT", "'abcdef'");
+		assertConstantWithValue(response, "UH-CONCAT", "'ABCDEF'");
 	}
 
 	@Test

--- a/libs/natls/src/test/java/org/amshove/natls/FindConstantsEndpointShould.java
+++ b/libs/natls/src/test/java/org/amshove/natls/FindConstantsEndpointShould.java
@@ -52,6 +52,7 @@ class FindConstantsEndpointShould extends EmptyProjectTest
 			1 C-CONCAT (A6) CONST<'abc' - 'def'>
 			1 U-CONCAT (U6) CONST <U'abc' - U'def'>
 			1 UH-CONCAT (U6) CONST <UH'00410042' - U'CDEF'>
+			1 AH-CONCAT (U6) CONST <'AB' - U'CDEF'>
 			END-DEFINE
 			""");
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
@@ -280,6 +280,19 @@ public class Lexer
 				case 'S':
 				case 'u':
 				case 'U':
+					if (scanner.peek(1) == '\'')
+					{
+						consumeUnicodeLiteral();
+					}
+					else if (scanner.peek(1) == 'H' && scanner.peek(2) == '\'')
+					{
+						consumeUnicodeHexLiteral();
+					}
+					else
+					{
+						consumeIdentifierOrKeyword();
+					}
+					continue;
 				case 'v':
 				case 'V':
 				case 'w':
@@ -1932,6 +1945,20 @@ public class Lexer
 		checkStringLiteralLength(previousUnsafe());
 	}
 
+	private void consumeUnicodeLiteral()
+	{
+		scanner.start();
+		scanner.advance(2); // U and '
+
+		if (!consumeStringToEnd(SyntaxKind.UNICODE_LITERAL))
+		{
+			return;
+		}
+
+		createAndAdd(SyntaxKind.UNICODE_LITERAL);
+	}
+
+
 	private void consumeHexLiteral()
 	{
 		scanner.start();
@@ -1949,6 +1976,11 @@ public class Lexer
 		{
 			addDiagnostic("Invalid HEX literal. Number of characters must be even but was %d.".formatted(hexLiteralChars), "Literal defined here", LexerError.UNKNOWN_CHARACTER);
 		}
+	}
+
+	private void consumeUnicodeHexLiteral()
+	{
+		scanner.start();
 	}
 
 	private boolean consumeStringToEnd(SyntaxKind kindToCreate)

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
@@ -284,13 +284,16 @@ public class Lexer
 					{
 						consumeUnicodeLiteral();
 					}
-					else if (scanner.peek(1) == 'H' && scanner.peek(2) == '\'')
-					{
-						consumeUnicodeHexLiteral();
-					}
 					else
 					{
-						consumeIdentifierOrKeyword();
+						if (scanner.peek(1) == 'H' && scanner.peek(2) == '\'')
+						{
+							consumeUnicodeHexLiteral();
+						}
+						else
+						{
+							consumeIdentifierOrKeyword();
+						}
 					}
 					continue;
 				case 'v':
@@ -1957,7 +1960,6 @@ public class Lexer
 
 		createAndAdd(SyntaxKind.UNICODE_LITERAL);
 	}
-
 
 	private void consumeHexLiteral()
 	{

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/Lexer.java
@@ -1981,6 +1981,20 @@ public class Lexer
 	private void consumeUnicodeHexLiteral()
 	{
 		scanner.start();
+		scanner.advance(3); // U, H, '
+
+		if (!consumeStringToEnd(SyntaxKind.UNICODE_HEX_LITERAL))
+		{
+			return;
+		}
+
+		createAndAdd(SyntaxKind.UNICODE_HEX_LITERAL);
+		checkStringLiteralLength(previousUnsafe());
+		var hexLiteralChars = previousUnsafe().source().length() - 4; // - H''
+		if (hexLiteralChars % 4 != 0)
+		{
+			addDiagnostic("Invalid UNICODE HEX literal. Number of characters must be divisible by 4, but was %d.".formatted(hexLiteralChars), "Literal defined here", LexerError.UNKNOWN_CHARACTER);
+		}
 	}
 
 	private boolean consumeStringToEnd(SyntaxKind kindToCreate)

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
@@ -1,6 +1,7 @@
 package org.amshove.natparse.lexing;
 
-public enum SyntaxKind {
+public enum SyntaxKind
+{
 	EOF(false, false, false), // end of file
 	LBRACKET(false, false, false),
 	RBRACKET(false, false, false),
@@ -303,7 +304,7 @@ public enum SyntaxKind {
 	INVESTIGATE(false, false, false),
 	JSON(false, false, false),
 	LIMIT(true, false, false), // can safely be an identifier, because the parser recognizes the LIMIT
-								// statement
+	// statement
 	LOOP(false, false, false),
 	MAP(true, false, false),
 	MOVE(false, false, false),
@@ -814,95 +815,109 @@ public enum SyntaxKind {
 	private final boolean isSystemVariable;
 	private final boolean isSystemFunction;
 
-	SyntaxKind(boolean canBeIdentifier, boolean isSystemVariable, boolean isSystemFunction) {
+	SyntaxKind(boolean canBeIdentifier, boolean isSystemVariable, boolean isSystemFunction)
+	{
 		this.canBeIdentifier = canBeIdentifier;
 		this.isSystemVariable = isSystemVariable;
 		this.isSystemFunction = isSystemFunction;
 	}
 
-	public boolean isIdentifier() {
+	public boolean isIdentifier()
+	{
 		return this == IDENTIFIER;
 	}
 
-	public boolean isSystemVariable() {
+	public boolean isSystemVariable()
+	{
 		return this.isSystemVariable;
 	}
 
-	public boolean isSystemFunction() {
+	public boolean isSystemFunction()
+	{
 		return this.isSystemFunction;
 	}
 
-	public boolean isBoolean() {
+	public boolean isBoolean()
+	{
 		return this == TRUE || this == FALSE;
 	}
 
-	public boolean isLiteralOrConst() {
-		return isBoolean() || this == NUMBER_LITERAL || this == STRING_LITERAL || this == DATE_LITERAL
-				|| this == HEX_LITERAL || this == TIME_LITERAL || this == EXTENDED_TIME_LITERAL;
+	public boolean isLiteralOrConst()
+	{
+		return isBoolean()
+			|| this == NUMBER_LITERAL
+			|| this == STRING_LITERAL || this == HEX_LITERAL
+			|| this == UNICODE_LITERAL || this == UNICODE_HEX_LITERAL
+			|| this == DATE_LITERAL || this == TIME_LITERAL || this == EXTENDED_TIME_LITERAL;
 	}
 
-	public boolean canBeIdentifier() {
+	public boolean canBeIdentifier()
+	{
 		return canBeIdentifier;
 	}
 
-	public boolean isAttribute() {
+	public boolean isAttribute()
+	{
 		return this == AD ||
-				this == AL ||
-				this == CC ||
-				this == CD ||
-				this == CV ||
-				this == DF ||
-				this == DL ||
-				this == DY ||
-				this == EM ||
-				this == EMU ||
-				this == ES ||
-				this == FC ||
-				this == FL ||
-				this == GC ||
-				this == HC ||
-				this == HE ||
-				this == HW ||
-				this == IC ||
-				this == ICU ||
-				this == IP ||
-				this == IS ||
-				this == KD ||
-				this == LC ||
-				this == LCU ||
-				this == LS ||
-				this == MC ||
-				this == MP ||
-				this == MS ||
-				this == NL ||
-				this == PC ||
-				this == PM ||
-				this == PS ||
-				this == SB ||
-				this == SF ||
-				this == SG ||
-				this == TC ||
-				this == TCU ||
-				this == UC ||
-				this == ZP ||
-				this == IN_ATTRIBUTE ||
-				this == OUT_ATTRIBUTE ||
-				this == OUTIN_ATTRIBUTE;
+			this == AL ||
+			this == CC ||
+			this == CD ||
+			this == CV ||
+			this == DF ||
+			this == DL ||
+			this == DY ||
+			this == EM ||
+			this == EMU ||
+			this == ES ||
+			this == FC ||
+			this == FL ||
+			this == GC ||
+			this == HC ||
+			this == HE ||
+			this == HW ||
+			this == IC ||
+			this == ICU ||
+			this == IP ||
+			this == IS ||
+			this == KD ||
+			this == LC ||
+			this == LCU ||
+			this == LS ||
+			this == MC ||
+			this == MP ||
+			this == MS ||
+			this == NL ||
+			this == PC ||
+			this == PM ||
+			this == PS ||
+			this == SB ||
+			this == SF ||
+			this == SG ||
+			this == TC ||
+			this == TCU ||
+			this == UC ||
+			this == ZP ||
+			this == IN_ATTRIBUTE ||
+			this == OUT_ATTRIBUTE ||
+			this == OUTIN_ATTRIBUTE;
 	}
 
-	public boolean closesStatement() {
+	public boolean closesStatement()
+	{
 		return this == END_IF || this == END_FOR || this == END_DECIDE || this == END_DEFINE || this == END_BREAK
-				|| this == END_ERROR || this == END_FIND || this == END_READ || this == END_SUBROUTINE
-				|| this == END_REPEAT || this == END_WORK;
+			|| this == END_ERROR || this == END_FIND || this == END_READ || this == END_SUBROUTINE
+			|| this == END_REPEAT || this == END_WORK;
 	}
 
-	public boolean opensStatementWithCloseKeyword() {
+	public boolean opensStatementWithCloseKeyword()
+	{
 		return this == IF || this == DEFINE || this == DECIDE || this == REPEAT || this == READ || this == FIND
-				|| this == FOR;
+			|| this == FOR;
 	}
 
 	@Override
-	public String toString() {
+	public String toString()
+	{
 		return name().replace("SV_", isSystemVariable ? "*" : "").replace("KW_", "").replace("_", "-");
 	}
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxKind.java
@@ -1,7 +1,6 @@
 package org.amshove.natparse.lexing;
 
-public enum SyntaxKind
-{
+public enum SyntaxKind {
 	EOF(false, false, false), // end of file
 	LBRACKET(false, false, false),
 	RBRACKET(false, false, false),
@@ -34,6 +33,8 @@ public enum SyntaxKind
 	NUMBER_LITERAL(false, false, false),
 	LESSER_GREATER(false, false, false),
 	STRING_LITERAL(false, false, false),
+	UNICODE_LITERAL(false, false, false),
+	UNICODE_HEX_LITERAL(false, false, false),
 	HEX_LITERAL(false, false, false),
 	DATE_LITERAL(false, false, false),
 	TIME_LITERAL(false, false, false),
@@ -48,7 +49,7 @@ public enum SyntaxKind
 	COLOR_ATTRIBUTE(false, false, false),
 
 	// System variables and functions
-	//   Application
+	// Application
 	SV_APPLIC_ID(false, true, false),
 	SV_APPLIC_NAME(false, true, false),
 	SV_COM(false, true, false),
@@ -86,8 +87,8 @@ public enum SyntaxKind
 	SV_TYPE(false, true, false),
 	SV_UBOUND(false, false, true),
 
-	//    Date and Time
-	//      Date
+	// Date and Time
+	// Date
 	SV_DATD(false, true, false),
 	SV_DAT4D(false, true, false),
 	SV_DATE(false, true, false),
@@ -103,7 +104,7 @@ public enum SyntaxKind
 	SV_DATV(false, true, false),
 	SV_DATVS(false, true, false),
 	SV_DATX(false, true, false),
-	//      Time
+	// Time
 	SV_TIMD(false, false, true),
 	SV_TIME(false, true, false),
 	SV_TIME_OUT(false, true, false),
@@ -112,7 +113,7 @@ public enum SyntaxKind
 	SV_TIMN(false, true, false),
 	SV_TIMX(false, true, false),
 
-	//   Input/Output
+	// Input/Output
 	SV_CURS_COL(false, true, false),
 	SV_CURS_FIELD(false, true, false),
 	SV_CURS_LINE(false, true, false),
@@ -129,12 +130,12 @@ public enum SyntaxKind
 	SV_WINDOW_POS(false, true, false),
 	SV_WINDOW_PS(false, true, false),
 
-	//    JSON
+	// JSON
 	SV_PARSE_LEVEL(false, false, true),
 	SV_PARSE_INDEX(false, false, true),
 	SV_PARSE_TYPE(false, false, true),
 
-	//    Natural Environment
+	// Natural Environment
 	SV_BROWSER_IO(false, true, false),
 	SV_DEVICE(false, true, false),
 	SV_GROUP(false, true, false),
@@ -153,7 +154,7 @@ public enum SyntaxKind
 	SV_USER_NAME(false, true, false),
 	SV_UUID(false, true, false),
 
-	//    System Environment
+	// System Environment
 	SV_CODEPAGE(false, true, false),
 	SV_HARDWARE(false, true, false),
 	SV_HOSTNAME(false, true, false),
@@ -170,14 +171,14 @@ public enum SyntaxKind
 	SV_WINMGR(false, true, false),
 	SV_WINMGRVERS(false, true, false),
 
-	//    XML
+	// XML
 	SV_PARSE_COL(false, false, true),
 	SV_PARSE_NAMESPACE_URI(false, false, true),
 	SV_PARSE_ROW(false, false, true),
 
 	// System Functions
 
-	//   Loops
+	// Loops
 	AVER(false, false, false),
 	COUNT(false, false, false),
 	MAX(false, false, false),
@@ -189,7 +190,7 @@ public enum SyntaxKind
 	SUM(false, false, false),
 	TOTAL(false, false, false),
 
-	//   Math
+	// Math
 	ABS(false, false, false),
 	ATN(false, false, false),
 	COS(false, false, false),
@@ -203,7 +204,7 @@ public enum SyntaxKind
 	TAN(false, false, false),
 	VAL(false, false, false),
 
-	//   Misc
+	// Misc
 	MAXVAL(false, false, true),
 	MINVAL(false, false, true),
 	TRANSLATE(true, false, true),
@@ -301,7 +302,8 @@ public enum SyntaxKind
 	INSERT(false, false, false),
 	INVESTIGATE(false, false, false),
 	JSON(false, false, false),
-	LIMIT(true, false, false), // can safely be an identifier, because the parser recognizes the LIMIT statement
+	LIMIT(true, false, false), // can safely be an identifier, because the parser recognizes the LIMIT
+								// statement
 	LOOP(false, false, false),
 	MAP(true, false, false),
 	MOVE(false, false, false),
@@ -812,102 +814,95 @@ public enum SyntaxKind
 	private final boolean isSystemVariable;
 	private final boolean isSystemFunction;
 
-	SyntaxKind(boolean canBeIdentifier, boolean isSystemVariable, boolean isSystemFunction)
-	{
+	SyntaxKind(boolean canBeIdentifier, boolean isSystemVariable, boolean isSystemFunction) {
 		this.canBeIdentifier = canBeIdentifier;
 		this.isSystemVariable = isSystemVariable;
 		this.isSystemFunction = isSystemFunction;
 	}
 
-	public boolean isIdentifier()
-	{
+	public boolean isIdentifier() {
 		return this == IDENTIFIER;
 	}
 
-	public boolean isSystemVariable()
-	{
+	public boolean isSystemVariable() {
 		return this.isSystemVariable;
 	}
 
-	public boolean isSystemFunction()
-	{
+	public boolean isSystemFunction() {
 		return this.isSystemFunction;
 	}
 
-	public boolean isBoolean()
-	{
+	public boolean isBoolean() {
 		return this == TRUE || this == FALSE;
 	}
 
-	public boolean isLiteralOrConst()
-	{
-		return isBoolean() || this == NUMBER_LITERAL || this == STRING_LITERAL || this == DATE_LITERAL || this == HEX_LITERAL || this == TIME_LITERAL || this == EXTENDED_TIME_LITERAL;
+	public boolean isLiteralOrConst() {
+		return isBoolean() || this == NUMBER_LITERAL || this == STRING_LITERAL || this == DATE_LITERAL
+				|| this == HEX_LITERAL || this == TIME_LITERAL || this == EXTENDED_TIME_LITERAL;
 	}
 
-	public boolean canBeIdentifier()
-	{
+	public boolean canBeIdentifier() {
 		return canBeIdentifier;
 	}
 
-	public boolean isAttribute()
-	{
+	public boolean isAttribute() {
 		return this == AD ||
-			this == AL ||
-			this == CC ||
-			this == CD ||
-			this == CV ||
-			this == DF ||
-			this == DL ||
-			this == DY ||
-			this == EM ||
-			this == EMU ||
-			this == ES ||
-			this == FC ||
-			this == FL ||
-			this == GC ||
-			this == HC ||
-			this == HE ||
-			this == HW ||
-			this == IC ||
-			this == ICU ||
-			this == IP ||
-			this == IS ||
-			this == KD ||
-			this == LC ||
-			this == LCU ||
-			this == LS ||
-			this == MC ||
-			this == MP ||
-			this == MS ||
-			this == NL ||
-			this == PC ||
-			this == PM ||
-			this == PS ||
-			this == SB ||
-			this == SF ||
-			this == SG ||
-			this == TC ||
-			this == TCU ||
-			this == UC ||
-			this == ZP ||
-			this == IN_ATTRIBUTE ||
-			this == OUT_ATTRIBUTE ||
-			this == OUTIN_ATTRIBUTE;
+				this == AL ||
+				this == CC ||
+				this == CD ||
+				this == CV ||
+				this == DF ||
+				this == DL ||
+				this == DY ||
+				this == EM ||
+				this == EMU ||
+				this == ES ||
+				this == FC ||
+				this == FL ||
+				this == GC ||
+				this == HC ||
+				this == HE ||
+				this == HW ||
+				this == IC ||
+				this == ICU ||
+				this == IP ||
+				this == IS ||
+				this == KD ||
+				this == LC ||
+				this == LCU ||
+				this == LS ||
+				this == MC ||
+				this == MP ||
+				this == MS ||
+				this == NL ||
+				this == PC ||
+				this == PM ||
+				this == PS ||
+				this == SB ||
+				this == SF ||
+				this == SG ||
+				this == TC ||
+				this == TCU ||
+				this == UC ||
+				this == ZP ||
+				this == IN_ATTRIBUTE ||
+				this == OUT_ATTRIBUTE ||
+				this == OUTIN_ATTRIBUTE;
 	}
 
-	public boolean closesStatement()
-	{
-		return this == END_IF || this == END_FOR || this == END_DECIDE || this == END_DEFINE || this == END_BREAK || this == END_ERROR || this == END_FIND || this == END_READ || this == END_SUBROUTINE || this == END_REPEAT || this == END_WORK;
+	public boolean closesStatement() {
+		return this == END_IF || this == END_FOR || this == END_DECIDE || this == END_DEFINE || this == END_BREAK
+				|| this == END_ERROR || this == END_FIND || this == END_READ || this == END_SUBROUTINE
+				|| this == END_REPEAT || this == END_WORK;
 	}
 
-	public boolean opensStatementWithCloseKeyword()
-	{
-		return this == IF || this == DEFINE || this == DECIDE || this == REPEAT || this == READ || this == FIND || this == FOR;
+	public boolean opensStatementWithCloseKeyword() {
+		return this == IF || this == DEFINE || this == DECIDE || this == REPEAT || this == READ || this == FIND
+				|| this == FOR;
 	}
 
 	@Override
-	public String toString()
-	{
+	public String toString() {
 		return name().replace("SV_", isSystemVariable ? "*" : "").replace("KW_", "").replace("_", "-");
 	}
 }

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
@@ -105,30 +105,31 @@ public class SyntaxToken implements IPosition
 		return stringLiteral.toString();
 	}
 
+	private String unwrappedString(int offset)
+	{
+		var quoteChar = source.substring(offset, offset + 1);
+		var escapedQuote = quoteChar + quoteChar;
+		return source.substring(offset + 1, source.length() - 1).replace(escapedQuote, quoteChar);
+	}
+
 	public String stringValue()
 	{
 		return switch (kind)
 		{
 			case HEX_LITERAL, UNICODE_HEX_LITERAL ->
 			{
-				var split = source.split("'");
-				if (split.length < 2)
-				{
-					// Empty literal H''
+				var quoteChar = source.substring(source.length() - 1);
+				var parts = source.split(quoteChar);
+				if (parts.length < 2) {
 					yield "";
 				}
-				var hexLiteral = split[1];
+				var hexLiteral = parts[1];
 				int size = kind == SyntaxKind.HEX_LITERAL ? 2 : 4;
 				yield fromHexBytes(hexLiteral, size);
 			}
 			case DATE_LITERAL, TIME_LITERAL, EXTENDED_TIME_LITERAL -> source.substring(2, source.length() - 1);
-			default ->
-			{
-				var quoteChar = source.substring(0, 1);
-				var escapedQuote = quoteChar + quoteChar;
-
-				yield source.substring(1, source.length() - 1).replace(escapedQuote, quoteChar);
-			}
+			case UNICODE_LITERAL -> unwrappedString(1);
+			default -> unwrappedString(0);
 		};
 	}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
@@ -83,22 +83,27 @@ public class SyntaxToken implements IPosition
 		return Integer.parseInt(source());
 	}
 
-	private String fromHexBytes(String hexLiteral, int codepointSize) {
+	private String fromHexBytes(String hexLiteral, int codepointSize)
+	{
 
 		var stringLiteral = new StringBuilder(hexLiteral.length() / codepointSize);
 		int ii = 0;
 
 		int codePoint = 0;
-		while (ii < hexLiteral.length()) {
+		while (ii < hexLiteral.length())
+		{
 			var hexByte = ii + 2 > hexLiteral.length()
 				? hexLiteral.charAt(ii) + "0"
 				: hexLiteral.substring(ii, ii + 2);
 			ii += 2;
 			codePoint += Integer.parseInt(hexByte, 16);
-			if (ii % codepointSize == 0) {
+			if (ii % codepointSize == 0)
+			{
 				stringLiteral.appendCodePoint(codePoint);
 				codePoint = 0;
-			} else {
+			}
+			else
+			{
 				codePoint <<= 8;
 			}
 		}
@@ -120,7 +125,8 @@ public class SyntaxToken implements IPosition
 			{
 				var quoteChar = source.substring(source.length() - 1);
 				var parts = source.split(quoteChar);
-				if (parts.length < 2) {
+				if (parts.length < 2)
+				{
 					yield "";
 				}
 				var hexLiteral = parts[1];

--- a/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/lexing/SyntaxToken.java
@@ -83,31 +83,43 @@ public class SyntaxToken implements IPosition
 		return Integer.parseInt(source());
 	}
 
+	private String fromHexBytes(String hexLiteral, int codepointSize) {
+
+		var stringLiteral = new StringBuilder(hexLiteral.length() / codepointSize);
+		int ii = 0;
+
+		int codePoint = 0;
+		while (ii < hexLiteral.length()) {
+			var hexByte = ii + 2 > hexLiteral.length()
+				? hexLiteral.charAt(ii) + "0"
+				: hexLiteral.substring(ii, ii + 2);
+			ii += 2;
+			codePoint += Integer.parseInt(hexByte, 16);
+			if (ii % codepointSize == 0) {
+				stringLiteral.appendCodePoint(codePoint);
+				codePoint = 0;
+			} else {
+				codePoint <<= 8;
+			}
+		}
+		return stringLiteral.toString();
+	}
+
 	public String stringValue()
 	{
 		return switch (kind)
 		{
-			case HEX_LITERAL ->
+			case HEX_LITERAL, UNICODE_HEX_LITERAL ->
 			{
 				var split = source.split("'");
-
 				if (split.length < 2)
 				{
 					// Empty literal H''
 					yield "";
 				}
-
 				var hexLiteral = split[1];
-				var stringLiteral = new StringBuilder(hexLiteral.length() / 2);
-				for (var i = 0; i < hexLiteral.length(); i += 2)
-				{
-					var hexPart = i + 2 > hexLiteral.length()
-						? hexLiteral.charAt(i) + "0" // just to prevent an Exception. The lexer raises a diagnostic for this
-						: hexLiteral.substring(i, i + 2);
-					stringLiteral.append((char) Integer.parseInt(hexPart, 16));
-				}
-
-				yield stringLiteral.toString();
+				int size = kind == SyntaxKind.HEX_LITERAL ? 2 : 4;
+				yield fromHexBytes(hexLiteral, size);
 			}
 			case DATE_LITERAL, TIME_LITERAL, EXTENDED_TIME_LITERAL -> source.substring(2, source.length() - 1);
 			default ->

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IDataType.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IDataType.java
@@ -35,14 +35,14 @@ public interface IDataType
 	 * Determines if this type fits into the given type. Implicit conversion is taken into account.<br/>
 	 * <strong>This does not compare by byte size</strong>
 	 *
-	 * ALPHA <-> UNICODE cares about _codepoint_ size, not bytes
-	 *   casts are done to/from the runtime codepage by default
+	 * ALPHA <-> UNICODE cares about _codepoint_ size, not bytes casts are done to/from the runtime codepage by default
 	 * (ALPHA|UNICODE) -> BINARY cares about bytes
 	 */
 	default boolean fitsInto(IDataType target)
 	{
 
-		if (this.isCharacterFamily() && target.isCharacterFamily()) {
+		if (this.isCharacterFamily() && target.isCharacterFamily())
+		{
 			return target.length() >= this.length();
 		}
 

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IDataType.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IDataType.java
@@ -21,6 +21,11 @@ public interface IDataType
 		return format() == NUMERIC || format() == PACKED || format() == FLOAT || format() == INTEGER;
 	}
 
+	default boolean isCharacterFamily()
+	{
+		return format() == ALPHANUMERIC || format() == UNICODE;
+	}
+
 	default boolean isAlphaNumericFamily()
 	{
 		return format() == ALPHANUMERIC || format() == UNICODE || format() == BINARY;
@@ -29,9 +34,18 @@ public interface IDataType
 	/**
 	 * Determines if this type fits into the given type. Implicit conversion is taken into account.<br/>
 	 * <strong>This does not compare by byte size</strong>
+	 *
+	 * ALPHA <-> UNICODE cares about _codepoint_ size, not bytes
+	 *   casts are done to/from the runtime codepage by default
+	 * (ALPHA|UNICODE) -> BINARY cares about bytes
 	 */
 	default boolean fitsInto(IDataType target)
 	{
+
+		if (this.isCharacterFamily() && target.isCharacterFamily()) {
+			return target.length() >= this.length();
+		}
+
 		var ourByteSize = this.hasDynamicLength() ? ONE_GIGABYTE : byteSize();
 		var theirByteSize = target.hasDynamicLength() ? ONE_GIGABYTE : target.byteSize();
 		var byteSizeFits = ourByteSize <= theirByteSize;

--- a/libs/natparse/src/main/java/org/amshove/natparse/natural/IDataType.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/natural/IDataType.java
@@ -41,7 +41,7 @@ public interface IDataType
 	default boolean fitsInto(IDataType target)
 	{
 
-		if (this.isCharacterFamily() && target.isCharacterFamily())
+		if (this.isCharacterFamily() && target.isCharacterFamily() && !target.hasDynamicLength())
 		{
 			return target.length() >= this.length();
 		}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
@@ -279,6 +279,11 @@ abstract class AbstractParser<T>
 			return consumeStringConcat(node);
 		}
 
+		if (peekAny(List.of(SyntaxKind.UNICODE_LITERAL, SyntaxKind.UNICODE_HEX_LITERAL)) && peekKind(1, SyntaxKind.MINUS) && peekAny(2, List.of(SyntaxKind.UNICODE_LITERAL, SyntaxKind.UNICODE_HEX_LITERAL)))
+		{
+			return consumeStringConcat(node);
+		}
+
 		return consumeSingleLiteral(node);
 	}
 
@@ -479,7 +484,7 @@ abstract class AbstractParser<T>
 			return;
 		}
 
-		var literal = consumeAny(List.of(SyntaxKind.NUMBER_LITERAL, SyntaxKind.STRING_LITERAL, SyntaxKind.HEX_LITERAL, SyntaxKind.TRUE, SyntaxKind.FALSE, SyntaxKind.DATE_LITERAL, SyntaxKind.TIME_LITERAL, SyntaxKind.EXTENDED_TIME_LITERAL));
+		var literal = consumeAny(List.of(SyntaxKind.NUMBER_LITERAL, SyntaxKind.STRING_LITERAL, SyntaxKind.UNICODE_LITERAL, SyntaxKind.HEX_LITERAL, SyntaxKind.UNICODE_HEX_LITERAL, SyntaxKind.TRUE, SyntaxKind.FALSE, SyntaxKind.DATE_LITERAL, SyntaxKind.TIME_LITERAL, SyntaxKind.EXTENDED_TIME_LITERAL));
 		previousNode = new TokenNode(literal);
 		node.addNode(previousNode);
 	}

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/AbstractParser.java
@@ -392,7 +392,14 @@ abstract class AbstractParser<T>
 		return false;
 	}
 
-	private static final Set<SyntaxKind> LITERAL_KINDS = Set.of(SyntaxKind.NUMBER_LITERAL, SyntaxKind.STRING_LITERAL, SyntaxKind.HEX_LITERAL, SyntaxKind.TRUE, SyntaxKind.FALSE, SyntaxKind.ASTERISK, SyntaxKind.DATE_LITERAL, SyntaxKind.TIME_LITERAL, SyntaxKind.EXTENDED_TIME_LITERAL);
+	private static final Set<SyntaxKind> LITERAL_KINDS = Set.of(
+		SyntaxKind.NUMBER_LITERAL,
+		SyntaxKind.STRING_LITERAL, SyntaxKind.HEX_LITERAL,
+		SyntaxKind.UNICODE_LITERAL, SyntaxKind.UNICODE_HEX_LITERAL,
+		SyntaxKind.TRUE, SyntaxKind.FALSE,
+		SyntaxKind.ASTERISK,
+		SyntaxKind.DATE_LITERAL, SyntaxKind.TIME_LITERAL, SyntaxKind.EXTENDED_TIME_LITERAL
+	);
 
 	private ILiteralNode consumeSingleLiteral(BaseSyntaxNode node) throws ParseError
 	{

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataParser.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/DefineDataParser.java
@@ -826,16 +826,16 @@ public class DefineDataParser extends AbstractParser<IDefineData>
 
 			switch (variable.type().format())
 			{
-				case ALPHANUMERIC ->
+				case ALPHANUMERIC, UNICODE ->
 				{
 					if (initialValueKind.isBoolean())
 					{
 						break;
 					}
-					expectInitialValueType(variable, initialValueKind, SyntaxKind.STRING_LITERAL, SyntaxKind.NUMBER_LITERAL, SyntaxKind.HEX_LITERAL);
+					expectInitialValueType(variable, initialValueKind, SyntaxKind.STRING_LITERAL, SyntaxKind.UNICODE_LITERAL, SyntaxKind.NUMBER_LITERAL, SyntaxKind.HEX_LITERAL, SyntaxKind.UNICODE_HEX_LITERAL);
 				}
 				case DATE -> expectInitialValueType(variable, initialValueKind, SyntaxKind.DATE_LITERAL);
-				case BINARY, CONTROL, TIME, UNICODE, NONE ->
+				case BINARY, CONTROL, TIME, NONE ->
 				{}
 				case FLOAT, NUMERIC, PACKED, INTEGER -> expectInitialValueType(variable, initialValueKind, SyntaxKind.NUMBER_LITERAL);
 				case LOGIC ->

--- a/libs/natparse/src/main/java/org/amshove/natparse/parsing/LiteralNode.java
+++ b/libs/natparse/src/main/java/org/amshove/natparse/parsing/LiteralNode.java
@@ -18,12 +18,14 @@ class LiteralNode extends TokenNode implements ILiteralNode
 		inferredType = switch (token.kind())
 		{
 			case STRING_LITERAL -> new LiteralType(DataFormat.ALPHANUMERIC, token.stringValue().trim().length());
+			case UNICODE_LITERAL -> new LiteralType(DataFormat.UNICODE, token.stringValue().trim().length());
 			case NUMBER_LITERAL -> inferNumeric(token);
 			case DATE_LITERAL -> new LiteralType(DataFormat.DATE, 4);
 			case TIME_LITERAL, EXTENDED_TIME_LITERAL -> new LiteralType(DataFormat.TIME, 7);
 
 			// docs(User-Defined constants): When a hexadecimal constant is transferred to another field, it will be treated as an alphanumeric value (format A).
 			case HEX_LITERAL -> new LiteralType(DataFormat.ALPHANUMERIC, token.stringValue().length());
+			case UNICODE_HEX_LITERAL -> new LiteralType(DataFormat.UNICODE, token.stringValue().length());
 
 			case TRUE, FALSE -> new LiteralType(DataFormat.LOGIC, 1);
 			case ASTERISK -> new LiteralType(DataFormat.NONE, 0);

--- a/libs/natparse/src/test/java/org/amshove/natparse/lexing/LexerForStringsShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/lexing/LexerForStringsShould.java
@@ -158,6 +158,13 @@ class LexerForStringsShould extends AbstractLexerTest
 	}
 
 	@Test
+	void containTheMultiCharUnicodeHexLiteralAsString()
+	{
+		var token = lexSingle("UH'00C4007000660065006C'");
+		assertThat(token.stringValue()).isEqualTo("Äpfel");
+	}
+
+	@Test
 	void containTheHexLiteralAsStringForMultipleCharactersIfOneCharacterIsMissing()
 	{
 		var token = lexSingle("H'31323'");

--- a/libs/natparse/src/test/java/org/amshove/natparse/lexing/LexerForStringsShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/lexing/LexerForStringsShould.java
@@ -74,6 +74,22 @@ class LexerForStringsShould extends AbstractLexerTest
 	}
 
 	@Test
+	void lexUnicodeHexStrings()
+	{
+		// U+00A5 = ¥
+		assertTokens("UH'00A5'", token(SyntaxKind.UNICODE_HEX_LITERAL, "UH'00A5'"));
+	}
+
+	@Test
+	void reportDiagnosticForWrongLengthUnicodeHexStrings()
+	{
+		assertDiagnostic(
+			"UH'00A'",
+			assertedDiagnostic(-1, 7, 0, 8, LexerError.UNKNOWN_CHARACTER)
+		);
+	}
+
+	@Test
 	void correctlyParseTimeFormats()
 	{
 		assertTokens(

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/DefineDataParserShould.java
@@ -443,6 +443,17 @@ class DefineDataParserShould extends AbstractParserTest<IDefineData>
 	}
 
 	@Test
+	void allowUnicodeValuesForAlphanumericFields()
+	{
+		assertParsesWithoutDiagnostics("""
+			DEFINE DATA LOCAL
+			01 #A1 (A1) INIT <U'A'>
+			02 #A2 (A1) INIT <UH'0041'>
+			END-DEFINE
+			""");
+	}
+
+	@Test
 	void allowMixedStringConcatInitialValuesForAlphanumericFields()
 	{
 		var defineData = assertParsesWithoutDiagnostics("""

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/LiteralTypeInferenceShould.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/LiteralTypeInferenceShould.java
@@ -16,6 +16,20 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 class LiteralTypeInferenceShould
 {
+
+	@ParameterizedTest
+	@CsvSource(
+		{
+			"H'4142',A2",
+			"U'AB',U2",
+			"UH'00410042',U2"
+		}
+	)
+	void inferTheCorrectSizesForAlphaFamilyLiterals(String source, String targetType)
+	{
+		assertCompatibleType(targetType, source);
+	}
+
 	@ParameterizedTest
 	@CsvSource(
 		{

--- a/libs/natparse/src/test/java/org/amshove/natparse/parsing/OperandParsingTests.java
+++ b/libs/natparse/src/test/java/org/amshove/natparse/parsing/OperandParsingTests.java
@@ -701,4 +701,19 @@ class OperandParsingTests extends AbstractOperandParsingTest
 		var operand = parseOperand("H'AA'");
 		assertLiteral(operand, SyntaxKind.HEX_LITERAL);
 	}
+
+	@Test
+	void parseUnicodeLiterals()
+	{
+		var operand = parseOperand("U'Äpfel'");
+		assertLiteral(operand, SyntaxKind.UNICODE_LITERAL);
+	}
+
+	@Test
+	void parseUnicodeHexLiterals()
+	{
+		var operand = parseOperand("UH'00C4007000660065006C'");
+		assertLiteral(operand, SyntaxKind.UNICODE_HEX_LITERAL);
+	}
+
 }


### PR DESCRIPTION
- Added support for Unicode and Unicode Hex string literals
- "Fits inside" behaviour for alpha <-> unicode is per code point, not per byte
- For unicode to binary, it's bytes

<img width="405" height="743" alt="image" src="https://github.com/user-attachments/assets/1ba082ea-85ba-4c85-ad33-124a991a1e2c" />

<img width="806" height="680" alt="image" src="https://github.com/user-attachments/assets/8f11ba96-7c52-4eff-ac78-b89921356845" />
